### PR TITLE
Add the trademark symbol in Essential studio and syncfusion term

### DIFF
--- a/Extension/ASPNET-Extension/Check-for-Updates.md
+++ b/Extension/ASPNET-Extension/Check-for-Updates.md
@@ -1,28 +1,28 @@
 ---
 layout: post
-title: Check for Updates | ASP.NET | Syncfusion
-description: Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio release.
+title: Check for Updates | ASP.NET |  Syncfusion
+description:  Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio  release.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Check for Updates in Syncfusion ASP.NET Web Forms
+# Check for Updates in  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms
 
-Syncfusion provides Extensions to update the most recent version of the Essential Studio release. Installing the most recent version ensures that you always have the most up-to-date features, fixes, and improvements.
+ Syncfusion<sup style="font-size:70%">&reg;</sup>   provides Extensions to update the most recent version of the Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Installing the most recent version ensures that you always have the most up-to-date features, fixes, and improvements.
 
-I> The Syncfusion Check for updates is available beginning with v17.1.0.32.
+I> The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Check for updates is available beginning with v17.1.0.32.
 
 You can check the availability of updates in Visual Studio and then install the update version if required.
 
-1. Choose **Syncfusion -> Check for Updates…** in the Visual Studio menu
+1. Choose ** Syncfusion<sup style="font-size:70%">&reg;</sup>   -> Check for Updates…** in the Visual Studio menu
 
-   ![Syncfusion check for updates menu](Check-for-Updates_images/Check-for-Updates_images-img1.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   check for updates menu](Check-for-Updates_images/Check-for-Updates_images-img1.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu is available under Extensions in Visual Studio menu.
    
 2. When an update is available, the Update dialog box appears.
 
-   ![Syncfusion check for updates wizard](Check-for-Updates_images/Check-for-Updates_images-img2.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   check for updates wizard](Check-for-Updates_images/Check-for-Updates_images-img2.png)
 
-3. Syncfusion Essential Studio can be downloaded from the Syncfusion website by clicking the **Download** button.
+3.  Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential Studio<sup style="font-size:70%">&reg;</sup>  can be downloaded from the  Syncfusion<sup style="font-size:70%">&reg;</sup>   website by clicking the **Download** button.

--- a/Extension/ASPNET-Extension/Overview.md
+++ b/Extension/ASPNET-Extension/Overview.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: ASP.NET Web Forms (Essential JS 1) Extension | Extension | Syncfusion
-description: The Syncfusion ASP.NET Web Forms Extensions provide quick access to create or configure the Syncfusion ASP.NET projects along with Essential JS 1 components
+title: ASP.NET Web Forms (Essential JS 1) Extension | Extension |  Syncfusion 
+description: The  Syncfusion ASP.NET Web Forms Extensions provide quick access to create or configure the  Syncfusion  ASP.NET projects along with Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control:  Syncfusion Extensions
 documentation: ug
 ---
 
@@ -11,36 +11,36 @@ documentation: ug
 
 ## Overview
 
-The Syncfusion ASP.NET (Essential JS 1) Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio. The Syncfusion ASP.NET Extensions supports Microsoft Visual Studio 2010 or higher.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Visual Studio Extensions can be accessed through the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu to create and configure the project with  Syncfusion<sup style="font-size:70%">&reg;</sup>   references in Visual Studio. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Extensions supports Microsoft Visual Studio 2010 or higher.
 
-I> The Syncfusion ASP.NET (Essential JS 1) menu option is available from v17.1.0.32.
+I> The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) menu option is available from v17.1.0.32.
 
-The Syncfusion provides the following extension supports in Visual Studio:
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   provides the following extension supports in Visual Studio:
 
-1.	[Syncfusion ASP.NET (Essential JS 1) Project Template](https://help.syncfusion.com/extension/aspnet-extension/syncfusion-project-templates): To create the Syncfusion ASP.NET (Essential JS 1) WebSite or Web application by adding the required Syncfusion references, Scripts, CSS, and Web.config entries.
-2.	[Project Conversion](https://help.syncfusion.com/extension/aspnet-extension/project-conversion): To convert an existing ASP.NET WebSite or Web application into the Syncfusion ASP.NET (Essential JS 1) WebSite or Web application by adding the required Syncfusion assemblies and resource files.
-3.	[Migrate Project](https://help.syncfusion.com/extension/aspnet-extension/project-migration): Migrate the existing Syncfusion ASP.NET WebSite or Web Application from one Essential Studio version to another version.
-4.	[Sample Creator](https://help.syncfusion.com/extension/aspnet-extension/sample-creator): Create the Syncfusion ASP.NET (Essential JS 1) WebSite or Web application projects with the required Syncfusion configuration to start development with the required Syncfusion controls.
-5.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the Syncfusion configuration and apply the fix like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly.
-6.	[Toolbox Configuration](https://help.syncfusion.com/common/essential-studio/utilities#toolbox-configuration): To configure the Syncfusion controls into the Visual Studio .NET toolbox.
+1.	[ Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Project Template](https://help.syncfusion.com/extension/aspnet-extension/syncfusion-project-templates): To create the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) WebSite or Web application by adding the required  Syncfusion<sup style="font-size:70%">&reg;</sup>   references, Scripts, CSS, and Web.config entries.
+2.	[Project Conversion](https://help.syncfusion.com/extension/aspnet-extension/project-conversion): To convert an existing ASP.NET WebSite or Web application into the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) WebSite or Web application by adding the required  Syncfusion<sup style="font-size:70%">&reg;</sup>   assemblies and resource files.
+3.	[Migrate Project](https://help.syncfusion.com/extension/aspnet-extension/project-migration): Migrate the existing  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET WebSite or Web Application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.
+4.	[Sample Creator](https://help.syncfusion.com/extension/aspnet-extension/sample-creator): Create the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) WebSite or Web application projects with the required  Syncfusion<sup style="font-size:70%">&reg;</sup>   configuration to start development with the required  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls.
+5.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the  Syncfusion<sup style="font-size:70%">&reg;</sup>   configuration and apply the fix like, wrong Framework  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly added to the project or missing any  Syncfusion<sup style="font-size:70%">&reg;</sup>   dependent assembly of a referred assembly.
+6.	[Toolbox Configuration](https://help.syncfusion.com/common/essential-studio/utilities#toolbox-configuration): To configure the  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls into the Visual Studio .NET toolbox.
 
 **No project selected in Visual Studio**
 
-![Syncfusion Menu when No project selected in Visual Studio](Overview-images/Syncfusion_Menu_OverView1.png)
+![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu when No project selected in Visual Studio](Overview-images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_OverView1.png)
 
 **Selected Microsoft ASP.NET WebSite or Web application in Visual Studio**
 
-![Syncfusion Menu when Selected Microsoft ASP.NET application in Visual Studio](Overview-images/Syncfusion_Menu_OverView2.png)
+![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu when Selected Microsoft ASP.NET application in Visual Studio](Overview-images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_OverView2.png)
 
-**Selected Syncfusion ASP.NET (Essential JS1) WebSite or Web application in Visual Studio**
+**Selected  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS1) WebSite or Web application in Visual Studio**
 
-![Syncfusion Menu when Selected Synfusion ASP.NET EJ1 application in Visual Studio](Overview-images/Syncfusion_Menu_OverView3.png)
+![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu when Selected Synfusion ASP.NET EJ1 application in Visual Studio](Overview-images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_OverView3.png)
 
-N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+N> In Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu available under Extension in Visual Studio menu.
 
-The Syncfusion ASP.NET Visual Studio Extensions are installed along with the following setups,
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Visual Studio Extensions are installed along with the following setups,
 
-* Essential Studio for Enterprise Edition with the platform ASP.NET
-* Essential Studio for ASP.NET
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platform ASP.NET
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET
 
 

--- a/Extension/ASPNET-Extension/Project-Conversion.md
+++ b/Extension/ASPNET-Extension/Project-Conversion.md
@@ -1,41 +1,41 @@
 ---
 layout: post
-title: Convert Project | ASP.NET Web Forms (Essential JS1) | Syncfusion
-description: Syncfusion ASP.NET Web Forms (Essential JS1) Project Conversion Extension that converts an existing ASP.NET project into a Essential JS1 ASP.NET Project.
+title: Convert Project | ASP.NET Web Forms (Essential JS1) |  Syncfusion 
+description:  Syncfusion  ASP.NET Web Forms (Essential JS1) Project Conversion Extension that converts an existing ASP.NET project into a Essential JS1 ASP.NET Project.
 platform: extension
-control: Syncfusion Extensions
+control:  Syncfusion  Extensions
 documentation: ug
 ---
 
-# Converting ASP.NET application to Syncfusion ASP.NET application
+# Converting ASP.NET application to  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET application
 
-The Syncfusion project conversion add-in for Visual Studio converts an existing ASP.NET application into the Syncfusion ASP.NET (Essential JS 1) application by adding the necessary assemblies and resource files.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   project conversion add-in for Visual Studio converts an existing ASP.NET application into the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) application by adding the necessary assemblies and resource files.
 
-I> The Syncfusion ASP.NET Web Application Project Conversion utility is available beginning with v13.1.0.30.
+I> The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Application Project Conversion utility is available beginning with v13.1.0.30.
 
-The following steps will assist you to use the Syncfusion Project conversion in your existing ASP.NET application:
+The following steps will assist you to use the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Project conversion in your existing ASP.NET application:
 
-> Before use, the Syncfusion ASP.NET Web Forms Project Conversion, check whether the **ASP.NET Web Forms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Conversion will not be shown.
+> Before use, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms Project Conversion, check whether the **ASP.NET Web Forms Extensions -  Syncfusion<sup style="font-size:70%">&reg;</sup>  ** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Conversion will not be shown.
 
 1. Open an existing Microsoft ASP.NET Project or create a new Microsoft ASP.NET Project.
 
 2. Open the conversion dialog by selecting one of the following options: 
 
    **Option 1**  
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Convert to Syncfusion ASP.NET Application…** in **Visual Studio**.
+   Click ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Convert to  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Application…** in **Visual Studio**.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Conversion via Syncfusion menu](Convert-Project_images/Syncfusion_Menu_Project_Conversion1.png)
+   ![ Syncfusion  Essential JS 1 ASP.NET Web Forms Project Conversion via  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu](Convert-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_Project_Conversion1.png)
 
-   N> In Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> In Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu is available under Extensions in Visual Studio menu.
 
    **Option 2**   
-   Right-click the Project from Solution Explorer, select **Syncfusion Web (Essential JS 1)**, and choose the **Convert to Syncfusion ASP.NET (Essential JS 1) Application...** Refer to the following screenshot for more information.
+   Right-click the Project from Solution Explorer, select ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Web (Essential JS 1)**, and choose the **Convert to  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Application...** Refer to the following screenshot for more information.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Conversion add-in](Convert-Project_images/Project-Conversion-img1.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Project Conversion add-in](Convert-Project_images/Project-Conversion-img1.png)
 
 3. The Project Conversion Wizard appears, allowing you to configure the project.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Conversion wizard](Convert-Project_images/Project-Conversion-img2.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Project Conversion wizard](Convert-Project_images/Project-Conversion-img2.png)
 
    The following configurations are used in the Project Conversion wizard:
 
@@ -43,15 +43,15 @@ The following steps will assist you to use the Syncfusion Project conversion in 
    
    ![Choose the assembly location from where assemblies to be referred to the ASP.NET Web Forms project](Convert-Project_images/Project-Conversion-img3.jpeg)
    
-   **Choose the Theme:** Based on the theme chosen, the project's master page will be updated. The Theme Preview section displays a preview of the components before converting them into a Syncfusion project.
+   **Choose the Theme:** Based on the theme chosen, the project's master page will be updated. The Theme Preview section displays a preview of the components before converting them into a  Syncfusion<sup style="font-size:70%">&reg;</sup>   project.
    
    ![Choose the theme to apply on the master page of the ASP.NET Web Forms project](Convert-Project_images/Project-Conversion-img4.png)
 
-   **Choose CDN Support:** The project's master page will be updated based on the required Syncfusion CDN links.
+   **Choose CDN Support:** The project's master page will be updated based on the required  Syncfusion<sup style="font-size:70%">&reg;</sup>   CDN links.
 
-   ![Choose CDN Support to refer the Syncfusion assets from CDN for ASP.NET Web Forms project](Convert-Project_images/Project-Conversion-img6.jpeg)
+   ![Choose CDN Support to refer the  Syncfusion assets from CDN for ASP.NET Web Forms project](Convert-Project_images/Project-Conversion-img6.jpeg)
  
-   **Copy Global Resources:** If you select the Copy Global Resources option, the Syncfusion localization culture files will be shipped to the project from the Installed Location.
+   **Copy Global Resources:** If you select the Copy Global Resources option, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   localization culture files will be shipped to the project from the Installed Location.
 
    ![Choose Copy Global Resources to ship the localization culture files for ASP.NET Web Forms project](Convert-Project_images/Project-Conversion-img7.jpeg)   
 
@@ -61,16 +61,16 @@ The following steps will assist you to use the Syncfusion Project conversion in 
 
    ![Choose the required controls](Convert-Project_images/Project-Conversion-img8.jpg)
 
-4. When you click the **Convert** button, the **Project Backup** dialog will appear. If you click **Yes** in the dialog, it will backup the current project before converting it to a Syncfusion project. If you choose **No**, the project will be converted to a Syncfusion project without a backup.
+4. When you click the **Convert** button, the **Project Backup** dialog will appear. If you click **Yes** in the dialog, it will backup the current project before converting it to a  Syncfusion<sup style="font-size:70%">&reg;</sup>   project. If you choose **No**, the project will be converted to a  Syncfusion<sup style="font-size:70%">&reg;</sup>   project without a backup.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Conversion backup dialog](Convert-Project_images/Project-Conversion-img9.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Project Conversion backup dialog](Convert-Project_images/Project-Conversion-img9.png)
 
-5. The necessary Syncfusion Assembly references, Scripts, and CSS, as well as the necessary Web.config entries, have been added to the project.
+5. The necessary  Syncfusion<sup style="font-size:70%">&reg;</sup>   Assembly references, Scripts, and CSS, as well as the necessary Web.config entries, have been added to the project.
 
-    ![Reference assemblies use of Syncfusion Essential JS 1 ASP.NET Web Forms Project](Convert-Project_images/Project-Conversion-img10.png)
+    ![Reference assemblies use of  Syncfusion   Essential JS 1 ASP.NET Web Forms Project](Convert-Project_images/Project-Conversion-img10.png)
 
-   ![Scripts and CSS for Syncfusion Essential JS 1 ASP.NET Web Forms Project](Convert-Project_images/Project-Conversion-img11.png)
+   ![Scripts and CSS for  Syncfusion   Essential JS 1 ASP.NET Web Forms Project](Convert-Project_images/Project-Conversion-img11.png)
 
-   ![Web.config assembly reference of Syncfusion Essential JS 1 ASP.NET Web Forms Project](Convert-Project_images/Project-Conversion-img12.png)
+   ![Web.config assembly reference of  Syncfusion Essential JS 1 ASP.NET Web Forms Project](Convert-Project_images/Project-Conversion-img12.png)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the  Syncfusion<sup style="font-size:70%">&reg;</sup>   license key to your project since  Syncfusion<sup style="font-size:70%">&reg;</sup>   introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the  Syncfusion<sup style="font-size:70%">&reg;</sup>   license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.

--- a/Extension/ASPNET-Extension/Project-Migration.md
+++ b/Extension/ASPNET-Extension/Project-Migration.md
@@ -1,53 +1,53 @@
 ---
 layout: post
-title: Upgrade Project | ASP.NET Web Forms | Syncfusion
-description: Project Migration is a add-in that allows you to migrate existing Syncfusion ASP.NET Web Forms project from one Essential Studio version to another version
+title: Upgrade Project | ASP.NET Web Forms |  Syncfusion  
+description: Project Migration is a add-in that allows you to migrate existing  Syncfusion  ASP.NET Web Forms project from one Essential Studio version to another version
 platform: extension
-control: Syncfusion Extensions
+control:  Syncfusion   Extensions
 documentation: ug
 ---
 
-# Upgrading Syncfusion ASP.NET application to latest version
+# Upgrading  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET application to latest version
 
-The Syncfusion ASP.NET migration add-in for Visual Studio allows you to migrate an existing Syncfusion ASP.NET application from one version of Essential Studio version to another version. This reduces the amount of manual work required when migrating the Syncfusion version.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET migration add-in for Visual Studio allows you to migrate an existing  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET application from one version of Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version. This reduces the amount of manual work required when migrating the  Syncfusion<sup style="font-size:70%">&reg;</sup>   version.
 
-I> The Syncfusion ASP.NET Web Application Project Migration utility is available beginning with v13.1.0.30.
+I> The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Application Project Migration utility is available beginning with v13.1.0.30.
 
-To migrate you’re existing Syncfusion ASP.NET application, follow the steps below.
+To migrate you’re existing  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET application, follow the steps below.
 
-> Before use, the Syncfusion ASP.NET Web Forms Project Migration, check whether the **ASP.NET Web Forms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Migration will not be shown.
+> Before use, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms Project Migration, check whether the **ASP.NET Web Forms Extensions -  Syncfusion<sup style="font-size:70%">&reg;</sup>  ** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Migration will not be shown.
 
 1. To launch Migration Wizard, select one of the following options:
 
    **Option 1**   
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Migrate Project…** in **Visual Studio**.
+   Click ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Migrate Project…** in **Visual Studio**.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Migration via Syncfusion menu](Upgrade-Project_images/Syncfusion_Menu_Project_Migration1.png)
+   ![ Syncfusion Essential JS 1 ASP.NET Web Forms Project Migration via  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu](Upgrade-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_Project_Migration1.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu is available under Extensions in Visual Studio menu.
 
    **Option 2**  
-   Right-click the **Syncfusion ASP.NET Application** from Solution Explorer and select **Syncfusion Web (Essential JS 1)**. Choose **Migrate the Essential JS 1 Project to Another version…**
+   Right-click the ** Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Application** from Solution Explorer and select ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Web (Essential JS 1)**. Choose **Migrate the Essential JS 1 Project to Another version…**
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Migration add-in](Upgrade-Project_images/Project-Migration_img1.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Project Migration add-in](Upgrade-Project_images/Project-Migration_img1.png)
 
-2. The **Project Migration** window appears. You can choose the required Essential Studio version that is installed in the machine.
+2. The **Project Migration** window appears. You can choose the required Essential Studio<sup style="font-size:70%">&reg;</sup>  version that is installed in the machine.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Migration wizard](Upgrade-Project_images/Project-Migration_img2.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Project Migration wizard](Upgrade-Project_images/Project-Migration_img2.png)
 
 3. The **Project Migration** window allows you to configure the following options:
 
-   i. **Essential Studio Version:** Choose a version from the list of Syncfusion versions that have been installed.
+   i. **Essential Studio Version:** Choose a version from the list of  Syncfusion<sup style="font-size:70%">&reg;</sup>   versions that have been installed.
    
    ii. **Assemblies From:** Choose the assembly location, from where the assembly will be added to the project.
 
     ![Choose the assembly location, from where the assembly is added to the project](Upgrade-Project_images/Project-Migration_img3.jpeg)
    
-4. Click the **Migrate** Button. The **Project Backup** dialogue box appears. If you select **Yes** in the dialog, it will backup the current project before migrating the Syncfusion project. If you select **No**, the project will be migrated to the required Syncfusion version without a backup.
+4. Click the **Migrate** Button. The **Project Backup** dialogue box appears. If you select **Yes** in the dialog, it will backup the current project before migrating the  Syncfusion<sup style="font-size:70%">&reg;</sup>   project. If you select **No**, the project will be migrated to the required  Syncfusion<sup style="font-size:70%">&reg;</sup>   version without a backup.
    
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project Migration backup dialog](Upgrade-Project_images/Project-Migration_img4.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Project Migration backup dialog](Upgrade-Project_images/Project-Migration_img4.png)
    
    
-5. The Syncfusion Reference Assemblies, Scripts, and CSS, Web. Config entries in the project are updated to the corresponding version.
+5. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Reference Assemblies, Scripts, and CSS, Web. Config entries in the project are updated to the corresponding version.
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the  Syncfusion<sup style="font-size:70%">&reg;</sup>   license key to your project since  Syncfusion<sup style="font-size:70%">&reg;</sup>   introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the  Syncfusion<sup style="font-size:70%">&reg;</sup>   license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.

--- a/Extension/ASPNET-Extension/Sample-Creator.md
+++ b/Extension/ASPNET-Extension/Sample-Creator.md
@@ -1,43 +1,43 @@
 ---
 layout: post
-title: Create Samples | ASP.NET Web Forms (Essential JS 1) | Syncfusion
-description: Sample Creator is the utility that allows you to create Syncfusion ASP.NET WebForms (Essential JS 1) Projects along with the samples
+title: Create Samples | ASP.NET Web Forms (Essential JS 1) |  Syncfusion 
+description: Sample Creator is the utility that allows you to create  Syncfusion   ASP.NET WebForms (Essential JS 1) Projects along with the samples
 platform: extension
-control: Syncfusion Extensions
+control:  Syncfusion  Extensions
 documentation: ug
 ---
 
-# Creating ASP.NET Samples through the Syncfusion ASP.NET Sample Creator
+# Creating ASP.NET Samples through the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Sample Creator
 
-The Syncfusion Sample Creator is a utility that allows you to create Syncfusion ASP.NET (Essential JS 1) Projects with sample code for required Syncfusion component features and configuration of Syncfusion components.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Sample Creator is a utility that allows you to create  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Projects with sample code for required  Syncfusion<sup style="font-size:70%">&reg;</sup>   component features and configuration of  Syncfusion<sup style="font-size:70%">&reg;</sup>   components.
 
-To create the Syncfusion ASP.NET (Essential JS 1) Application using the Sample Creator utility, follow the steps below:
+To create the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Application using the Sample Creator utility, follow the steps below:
 
 1. To launch the ASP.NET (Essential JS 1) Sample Creator, select one of the following options:
 
    **Option 1:**  
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Launch Sample Creator…** in **Visual Studio**.
+   Click ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Launch Sample Creator…** in **Visual Studio**.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms control panel to launch Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator](Create-Samples_images/Syncfusion_Menu_Sample_Creator.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms control panel to launch  Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Sample Creator](Create-Samples_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_Sample_Creator.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu is available under Extensions in Visual Studio menu.
 
    **Option 2:**
-   Launch the Syncfusion ASP.NET (Essential JS 1) Control Panel. To run the ASP.NET (Essential JS 1) Sample Creator, click the Sample Creator button. More information can be found in the screenshot below.
+   Launch the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Control Panel. To run the ASP.NET (Essential JS 1) Sample Creator, click the Sample Creator button. More information can be found in the screenshot below.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms control panel to launch Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator](Create-Samples_images/SampleCreator-img1.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms control panel to launch  Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Sample Creator](Create-Samples_images/SampleCreator-img1.png)
 
-2. The Syncfusion components and their features are listed in the ASP.NET (Essential JS 1) Sample Creator.
+2. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   components and their features are listed in the ASP.NET (Essential JS 1) Sample Creator.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator wizard](Create-Samples_images/SampleCreator-img2.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Sample Creator wizard](Create-Samples_images/SampleCreator-img2.png)
 
-   **Components Selection:** Choose the required components. The components are grouped with Syncfusion products, and the components are grouped by product.
+   **Components Selection:** Choose the required components. The components are grouped with  Syncfusion<sup style="font-size:70%">&reg;</sup>   products, and the components are grouped by product.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator controls selection](Create-Samples_images/SampleCreator-img3.jpeg)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Sample Creator controls selection](Create-Samples_images/SampleCreator-img3.jpeg)
 
    **Feature Selection:** Based on the components, the feature is enabled to choose the features of the corresponding components.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator features selection](Create-Samples_images/SampleCreator-img4.jpeg)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Sample Creator features selection](Create-Samples_images/SampleCreator-img4.jpeg)
 
    **Project Configuration**
 
@@ -49,35 +49,35 @@ To create the Syncfusion ASP.NET (Essential JS 1) Application using the Sample C
 
       * **VS Version:** Choose the Visual Studio version and Framework.
 
-      * **Name:** Name your Syncfusion ASP.NET Web Forms (Essential JS 1) Application.
+      * **Name:** Name your  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms (Essential JS 1) Application.
 
       * **Location:** Choose the target location of your project.
 
-      * **Theme Selection:** Choose the required theme. This section shows the controls preview before creating the Syncfusion project.
+      * **Theme Selection:** Choose the required theme. This section shows the controls preview before creating the  Syncfusion<sup style="font-size:70%">&reg;</sup>   project.
 
-      ![Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator project configuration selection](Create-Samples_images/SampleCreator-img5.png)
+      ![ Syncfusion   Essential JS 1 ASP.NET Web Forms Sample Creator project configuration selection](Create-Samples_images/SampleCreator-img5.png)
 
    2. Click the **Create** button. After you've finished creating the project, open it by clicking **Yes**. If you click **No**, the project's corresponding location will be opened. For more information, see the screenshot below.
 
-      ![The project successfully created using Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator](Create-Samples_images/SampleCreator-img6.png)
+      ![The project successfully created using  Syncfusion Essential JS 1 ASP.NET Web Forms Sample Creator](Create-Samples_images/SampleCreator-img6.png)
 
-   3. The new Syncfusion ASP.NET (Essential JS 1) project is created with the resources.
+   3. The new  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) project is created with the resources.
 
       * Added the required Controllers and View files in the project.
 
-        ![Required ASPX and Class files for Syncfusion Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img7.png)
+        ![Required ASPX and Class files for  Syncfusion   Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img7.png)
 
-      * Under Project Reference, the necessary Syncfusion assemblies are added for selected components.
+      * Under Project Reference, the necessary  Syncfusion<sup style="font-size:70%">&reg;</sup>   assemblies are added for selected components.
 
-        ![Required reference assemblies for Syncfusion Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img8.png)
+        ![Required reference assemblies for  Syncfusion  Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img8.png)
 
-      * Syncfusion ASP.NET (Essential JS 1) scripts and theme files were included.
+      *  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) scripts and theme files were included.
 
-        ![Required Scripts and Themes files for Syncfusion Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img9.png)
+        ![Required Scripts and Themes files for  Syncfusion  Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img9.png)
 
-      * Configure the Web.Config file by adding the Syncfusion reference assemblies, namespaces and controls.
+      * Configure the Web.Config file by adding the  Syncfusion<sup style="font-size:70%">&reg;</sup>   reference assemblies, namespaces and controls.
 
-        ![Required Web.config assembliesa and namespaces entry for Syncfusion Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img10.png)
+        ![Required Web.config assembliesa and namespaces entry for  Syncfusion  Essential JS 1 ASP.NET Web Forms controls](Create-Samples_images/SampleCreator-img10.png)
 
 
    

--- a/Extension/ASPNET-Extension/Syncfusion-Project-Templates.md
+++ b/Extension/ASPNET-Extension/Syncfusion-Project-Templates.md
@@ -1,88 +1,88 @@
 ---
 layout: post
-title: Create Project | ASP.NET Web Forms | Syncfusion
-description: Syncfusion provides Visual Studio Project Templates for the ASP.NET platform to create Syncfusion ASP.NET Web Application using Essential JS 1 components
+title: Create Project | ASP.NET Web Forms |  Syncfusion
+description:  Syncfusion  provides Visual Studio Project Templates for the ASP.NET platform to create  Syncfusion   ASP.NET Web Application using Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control:  Syncfusion   Extensions
 documentation: ug
 ---
 
-# Creating SyncfusionASP.NET Web Application
+# Creating  Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Web Application
 
-Syncfusion offers **Visual Studio Project Templates** for the Syncfusion ASP.NET platform, which can be used to create a Syncfusion ASP.NET Web Application or a Syncfusion ASP.NET Web Site.
+ Syncfusion<sup style="font-size:70%">&reg;</sup>   offers **Visual Studio Project Templates** for the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET platform, which can be used to create a  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Application or a  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Site.
 
-I> Syncfusion ASP.NET Website templates are available beginning with v12.2.0.36, and Syncfusion ASP.NET Web Application templates are available beginning with v13.3.0.7. 
+I>  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Website templates are available beginning with v12.2.0.36, and  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Application templates are available beginning with v13.3.0.7. 
 
-To create the **Syncfusion ASP.NET (Essential JS 1) Application** using the **Visual Studio Project Template**, follow the steps below:
+To create the ** Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Application** using the **Visual Studio Project Template**, follow the steps below:
 
-> Before use the Syncfusion ASP.NET Web Forms Project Template, check whether the **ASP.NET Web Forms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
+> Before use the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms Project Template, check whether the **ASP.NET Web Forms Extensions -  Syncfusion<sup style="font-size:70%">&reg;</sup>  ** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
 
-1. To create a Syncfusion ASP.NET (Essential JS 1) Web Forms project, use one of the following methods:
+1. To create a  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET (Essential JS 1) Web Forms project, use one of the following methods:
 
    **Option 1**  
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Create New Syncfusion ASPNET Web Forms Project…** in **Visual Studio**.
+   Click ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Create New  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASPNET Web Forms Project…** in **Visual Studio**.
 
-   ![Choose Syncfusion ASP.NET Web Application or Syncfusion ASP.NET Web Site from Visual Studio new project dialog via Syncfusion menu](Create-Project_images/Syncfusion_Menu_ProjectTemplate.png)
+   ![Choose  Syncfusion   ASP.NET Web Application or  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Site from Visual Studio new project dialog via  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_ProjectTemplate.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu is available under Extensions in Visual Studio menu.
 
    **Option 2**  
-   Choose **File > New > Project** and navigate to **Syncfusion > Web > Syncfusion ASP.NET Web Forms Application** in **Visual Studio**.
+   Choose **File > New > Project** and navigate to ** Syncfusion<sup style="font-size:70%">&reg;</sup>   > Web >  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms Application** in **Visual Studio**.
 
-   ![Choose Syncfusion ASP.NET Web Forms Application from Visual Studio new project dialog](Create-Project_images/Syncfusion-Project-Templates-img1.png)
+   ![Choose  Syncfusion ASP.NET Web Forms Application from Visual Studio new project dialog](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img1.png)
 
 2. Name the **project**, select the destination location, and configure the project's .NET Framework, then click **OK**. The Project Configuration Wizard is displayed. 
 
-   N> The minimum target framework for Syncfusion ASP.NET Project Templates is 3.5.
+   N> The minimum target framework for  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Project Templates is 3.5.
 
-3. Using the following Project Configuration window, select the options to configure the Syncfusion ASP.NET Web Forms Application.
+3. Using the following Project Configuration window, select the options to configure the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms Application.
 
-   ![Syncfusion Essential JS 1 ASP.NET Web Forms Project configuration wizard](Create-Project_images/Syncfusion-Project-Templates-img2.png)
+   ![ Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms Project configuration wizard](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img2.png)
 
 **Project Configurations**
 
 **Project Type:** Choose the appropriate Project Type either Website or WebApplication.
 
-   ![Choose appropriate Project Type version](Create-Project_images/Syncfusion-Project-Templates-img3.png)
+   ![Choose appropriate Project Type version](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img3.png)
 
 **Theme:** Choose the appropriate theme.
 
-   ![Choose required theme](Create-Project_images/Syncfusion-Project-Templates-img4.png)
+   ![Choose required theme](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img4.png)
 
 **Language:** Choose the language, either C# or VB.
 
-   ![Choose required language](Create-Project_images/Syncfusion-Project-Templates-img5.png)
+   ![Choose required language](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img5.png)
 
 **Assemblies From:** Choose the assembly location, from where the assembly will be added to the project.
 
-   ![Choose the assembly location from where it is going to be added to the prject](Create-Project_images/Syncfusion-Project-Templates-img6.png)
+   ![Choose the assembly location from where it is going to be added to the prject](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img6.png)
 
-**Assets From:** Choose the Syncfusion Essential JS assets to be added to the ASP.NET Web Forms Project from the NuGet, CDN, or Installed Location.
+**Assets From:** Choose the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS assets to be added to the ASP.NET Web Forms Project from the NuGet, CDN, or Installed Location.
 
-   ![Choose the Syncfusion Essential JS assets to ASP.NET Web Forms Project, either NuGet, CDN or Installed Location](Create-Project_images/Syncfusion-Project-Templates-img7.png)
+   ![Choose the  Syncfusion   Essential JS assets to ASP.NET Web Forms Project, either NuGet, CDN or Installed Location](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img7.png)
 
 **Installed Version** Choose the version of the project that needs to be created.
 
-   ![Choose the Version](Create-Project_images/Syncfusion-Project-Templates-img8.png)
+   ![Choose the Version](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img8.png)
 
-4. Select the components, Assemblies, and Scripts that should be added to the project, and then click the Create button. The Syncfusion ASP.NET Web Forms project will be created.
+4. Select the components, Assemblies, and Scripts that should be added to the project, and then click the Create button. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms project will be created.
 
-   ![Syncfusion Essential ASP.NET Web Feature selection](Create-Project_images/Syncfusion-Project-Templates-img9.png)
+   ![ Syncfusion   Essential ASP.NET Web Feature selection](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img9.png)
 
-   ![Syncfusion Essential ASP.NET Web Feature selection](Create-Project_images/Syncfusion-Project-Templates-img14.PNG)
+   ![ Syncfusion   Essential ASP.NET Web Feature selection](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img14.PNG)
 
-5. The necessary Syncfusion Assembly references, Scripts, and CSS, as well as the necessary Web.config entries, have been added to the project.
+5. The necessary  Syncfusion<sup style="font-size:70%">&reg;</sup>   Assembly references, Scripts, and CSS, as well as the necessary Web.config entries, have been added to the project.
 
-   ![References of Syncfusion Essential JS 1 ASP.NET Web Forms project](Create-Project_images/Syncfusion-Project-Templates-img10.png)
+   ![References of  Syncfusion   Essential JS 1 ASP.NET Web Forms project](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img10.png)
 
-   ![Scripts and Themes of Syncfusion Essential JS 1 ASP.NET Web Forms project](Create-Project_images/Syncfusion-Project-Templates-img11.png)
+   ![Scripts and Themes of  Syncfusion   Essential JS 1 ASP.NET Web Forms project](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img11.png)
 
-   ![Web.config references of Syncfusion Essential JS 1 ASP.NET Web Forms project](Create-Project_images/Syncfusion-Project-Templates-img12.png)
+   ![Web.config references of  Syncfusion   Essential JS 1 ASP.NET Web Forms project](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img12.png)
    
 
-6.Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6.Then,  Syncfusion<sup style="font-size:70%">&reg;</sup>   licensing registration required message box will be shown if you installed the trial setup or NuGet packages since  Syncfusion<sup style="font-size:70%">&reg;</sup>   introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the  Syncfusion<sup style="font-size:70%">&reg;</sup>   license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-   ![Syncfusion license registration information message box for Syncfusion Essential JS 1 ASP.NET Web Forms project](Create-Project_images/Syncfusion-Project-Templates-img13.jpeg)
+   ![ Syncfusion   license registration information message box for  Syncfusion<sup style="font-size:70%">&reg;</sup>   Essential JS 1 ASP.NET Web Forms project](Create-Project_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  -Project-Templates-img13.jpeg)
 
 
 

--- a/Extension/ASPNET-Extension/Toolbox-Configuration.md
+++ b/Extension/ASPNET-Extension/Toolbox-Configuration.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Toolbox Configuration | ASP.NET | Syncfusion
-description: This section provides information regarding all the Syncfusion Essential Studio utilities and its usage
+title: Toolbox Configuration | ASP.NET |  Syncfusion 
+description: This section provides information regarding all the  Syncfusion  Essential Studio  utilities and its usage
 platform: extension
 control: Essential Studio
 documentation: ug
@@ -9,27 +9,27 @@ documentation: ug
 
 # Toolbox Configuration
 
-The Syncfusion Toolbox Installer utility incorporates the Syncfusion ASP.NET Web Forms components into the Visual Studio.NET toolbox.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox Installer utility incorporates the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms components into the Visual Studio.NET toolbox.
 
-N> Toolbox configuration support is not available in the Visual Studio Express Edition. However, you can manually configure the Syncfusion components in the Visual Studio Express Toolbox. To do so, see [Manual Toolbox Configuration](https://help.syncfusion.com/common/faq/how-to-configure-the-toolbox-of-visual-studio-manually).
+N> Toolbox configuration support is not available in the Visual Studio Express Edition. However, you can manually configure the  Syncfusion<sup style="font-size:70%">&reg;</sup>   components in the Visual Studio Express Toolbox. To do so, see [Manual Toolbox Configuration](https://help.syncfusion.com/common/faq/how-to-configure-the-toolbox-of-visual-studio-manually).
 
-If the <b>“Configure Syncfusion components in Visual Studio”</b> checkbox is selected from the installer UI while installing the Syncfusion ASP.NET Web Forms installer, Syncfusion components will be automatically configured in the Visual Studio toolbox.
+If the <b>“Configure  Syncfusion<sup style="font-size:70%">&reg;</sup>   components in Visual Studio”</b> checkbox is selected from the installer UI while installing the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms installer,  Syncfusion<sup style="font-size:70%">&reg;</sup>   components will be automatically configured in the Visual Studio toolbox.
 
-To add the Syncfusion ASP.NET Web Forms components via the Syncfusion Toolbox Installer, perform the following steps:
+To add the  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms components via the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox Installer, perform the following steps:
 
 1. To launch the Toolbox configuration utility, select one of the following options:
 
    **Option 1:**   
-   Open the Syncfusion Control Panel, click **Add On and Utilities > Toolbox Installer**.
+   Open the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Control Panel, click **Add On and Utilities > Toolbox Installer**.
    
    ![Add On and Utilities](Toolbox-Configuration_images/Toolbox-Configuration_img1.png)
    
    **Option 2:**  
-   Click **Syncfusion menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Toolbox Configuration...** in **Visual Studio**
+   Click ** Syncfusion<sup style="font-size:70%">&reg;</sup>   menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Toolbox Configuration...** in **Visual Studio**
 
-   ![Toolbox Installer via Syncfusion menu](Toolbox-Configuration_images/Syncfusion_Menu_Toolbox.png)
+   ![Toolbox Installer via  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu](Toolbox-Configuration_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_Toolbox.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu is available under Extensions in Visual Studio menu.
 
 2. Toolbox Installer will be opened.
 
@@ -37,17 +37,17 @@ To add the Syncfusion ASP.NET Web Forms components via the Syncfusion Toolbox In
 
    The following options are available in Toolbox Configuration:
 
-   * Install VS2005 – Configures Framework 2.0 Syncfusion controls in VS 2005 toolbox.
-   * Install VS2008 – Configures Framework 3.5 Syncfusion controls in VS 2008 toolbox.
-   * Install VS2010 – Configures Framework 4.0 Syncfusion controls in VS 2010 toolbox.
-   * Install VS2012 – Configures Framework 4.5 Syncfusion controls in VS 2012 toolbox.
-   * Install VS2013 – Configures Framework 4.5.1 Syncfusion controls in VS 2013 toolbox.
-   * Install VS2015 – Configures Framework 4.6 Syncfusion controls in VS 2015 toolbox.
-   * Install VS2017 – Configures Framework 4.6 Syncfusion controls in VS 2017 toolbox.
-   * Install VS2019 – Configures Framework 4.6 Syncfusion controls in VS 2019 toolbox.
-   * Install VS2022 – Configures Framework 4.6 Syncfusion components in VS 2022 toolbox.
+   * Install VS2005 – Configures Framework 2.0  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2005 toolbox.
+   * Install VS2008 – Configures Framework 3.5  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2008 toolbox.
+   * Install VS2010 – Configures Framework 4.0  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2010 toolbox.
+   * Install VS2012 – Configures Framework 4.5  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2012 toolbox.
+   * Install VS2013 – Configures Framework 4.5.1  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2013 toolbox.
+   * Install VS2015 – Configures Framework 4.6  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2015 toolbox.
+   * Install VS2017 – Configures Framework 4.6  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2017 toolbox.
+   * Install VS2019 – Configures Framework 4.6  Syncfusion<sup style="font-size:70%">&reg;</sup>   controls in VS 2019 toolbox.
+   * Install VS2022 – Configures Framework 4.6  Syncfusion<sup style="font-size:70%">&reg;</sup>   components in VS 2022 toolbox.
    
-    N> You can also configure Syncfusion components from a lower version Framework assembly to higher version of Visual Studio.
+    N> You can also configure  Syncfusion<sup style="font-size:70%">&reg;</sup>   components from a lower version Framework assembly to higher version of Visual Studio.
    
 3. An Information message is displayed, indicating that Toolbox has been successfully configured. Click OK.
 

--- a/Extension/ASPNET-Extension/Troubleshooting.md
+++ b/Extension/ASPNET-Extension/Troubleshooting.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: Syncfusion Troubleshooter | ASP.NET | Syncfusion
-description: Syncfusion Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in Syncfusion assembly reference, webconfig entries in projects.
+title:  Syncfusion  Troubleshooter | ASP.NET |  Syncfusion  
+description:  Syncfusion  Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in  Syncfusion   assembly reference, webconfig entries in projects.
 platform: extension
-control: Syncfusion Extensions
+control:  Syncfusion   Extensions
 documentation: ug
 ---
 
 # Troubleshoot the project
 
-Troubleshoot the project with the Syncfusion configuration and apply the fix, such as wrong.NET Framework version of a Syncfusion assembly to the project or missing any Syncfusion dependent assembly of a referred assembly. The Syncfusion Troubleshooter can perform the following tasks:
+Troubleshoot the project with the  Syncfusion<sup style="font-size:70%">&reg;</sup>   configuration and apply the fix, such as wrong.NET Framework version of a  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly to the project or missing any  Syncfusion<sup style="font-size:70%">&reg;</sup>   dependent assembly of a referred assembly. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter can perform the following tasks:
 
 * Report the Configuration issues.  
 
@@ -17,41 +17,41 @@ Troubleshoot the project with the Syncfusion configuration and apply the fix, su
 
 ## Report the Configuration issues
 
-The steps below will assist you in using the Syncfusion Troubleshooter by Visual Studio.
+The steps below will assist you in using the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter by Visual Studio.
 
-> Before use the Syncfusion Troubleshooter for ASP.NET Web Forms, check whether the **ASP.NET Web Forms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. 
+> Before use the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter for ASP.NET Web Forms, check whether the **ASP.NET Web Forms Extensions -  Syncfusion<sup style="font-size:70%">&reg;</sup>  ** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. 
 
-1. To launch the Syncfusion Troubleshooter Wizard, select one of the options below:
+1. To launch the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter Wizard, select one of the options below:
    
    **Option 1**  
-   Open an existing Syncfusion ASP.NET Web Forms Application, Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Troubleshoot…** in Visual Studio.
+   Open an existing  Syncfusion<sup style="font-size:70%">&reg;</sup>   ASP.NET Web Forms Application, Click ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Menu** and choose **Essential Studio for ASP.NET Web Forms (EJ1) > Troubleshoot…** in Visual Studio.
 
-   ![Syncfusion Troubleshooter via Syncfusion menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter.png)
+   ![ Syncfusion   Troubleshooter via  Syncfusion   menu]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  _Menu_Troubleshooter.png)
 
-   N> In Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> In Visual Studio 2019,  Syncfusion<sup style="font-size:70%">&reg;</sup>   menu is available under Extensions in Visual Studio menu.
 
    **Option 2**  
-   Right-click the Project file in Solution Explorer, then select the command **Syncfusion Troubleshooter…**
+   Right-click the Project file in Solution Explorer, then select the command ** Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter…**
 
-   ![Syncfusion Troubleshooter add-in](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img1.png)
+   ![ Syncfusion  Troubleshooter add-in]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img1.png)
 
-2. Now, analyze the project, and if any issues are discovered, it will report the project configuration issues of Syncfusion components in the Troubleshooter dialogue. If the project has no configuration issues, the dialogue box will indicate that no configuration changes are required in the following areas:
+2. Now, analyze the project, and if any issues are discovered, it will report the project configuration issues of  Syncfusion<sup style="font-size:70%">&reg;</sup>   components in the Troubleshooter dialogue. If the project has no configuration issues, the dialogue box will indicate that no configuration changes are required in the following areas:
 
-    * Syncfusion assembly references.
+    *  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly references.
 
-    * Syncfusion NuGet Packages. 
+    *  Syncfusion<sup style="font-size:70%">&reg;</sup>   NuGet Packages. 
 
-    * Syncfusion Web.config Entries.
+    *  Syncfusion<sup style="font-size:70%">&reg;</sup>   Web.config Entries.
 
-    * Syncfusion Script files.
+    *  Syncfusion<sup style="font-size:70%">&reg;</sup>   Script files.
 
     * Toolbox Configuration.
 
-   ![No configuration changes required dialog box](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img2.png)
+   ![No configuration changes required dialog box]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img2.png)
 
-   I> The Syncfusion Troubleshooter command will be visible only for Syncfusion projects, which means the project must contain the referred Syncfusion assemblies or NuGet packages.
+   I> The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter command will be visible only for  Syncfusion<sup style="font-size:70%">&reg;</sup>   projects, which means the project must contain the referred  Syncfusion<sup style="font-size:70%">&reg;</sup>   assemblies or NuGet packages.
 
-   The Syncfusion Troubleshooter handles the following project configuration issues: 
+   The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter handles the following project configuration issues: 
 
    1. Assembly reference issues.
 
@@ -65,134 +65,134 @@ The steps below will assist you in using the Syncfusion Troubleshooter by Visual
 
 ### Assembly reference issues
 
-The Syncfusion Troubleshooter handles the assembly reference issues listed below in Syncfusion Projects.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter handles the assembly reference issues listed below in  Syncfusion<sup style="font-size:70%">&reg;</sup>   Projects.
 
 1. Dependent assemblies are missing for referred assemblies from project. 
 
-   **For Instance:**  If the “Syncfusion.EJ.Pivot” assembly is referenced in the project but “Syncfusion.PivotAnalysis.Base” and other dependent assemblies of Syncfusion.EJ.Pivot are not referenced in the project, the Syncfusion Troubleshooter will report that the dependent assembly is missing.
+   **For Instance:**  If the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.Pivot” assembly is referenced in the project but “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .PivotAnalysis.Base” and other dependent assemblies of  Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.Pivot are not referenced in the project, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will report that the dependent assembly is missing.
 
-   ![Dependent assemblies missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img3.png)
+   ![Dependent assemblies missing issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img3.png)
 
-2. The Syncfusion assembly version is mismatched. In the same project, compare all Syncfusion assembly versions. If any Syncfusion assembly version inconsistency is discovered, the Syncfusion Troubleshooter will display the Syncfusion assembly’s version mismatch.
+2. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly version is mismatched. In the same project, compare all  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly versions. If any  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly version inconsistency is discovered, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display the  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly’s version mismatch.
 
-   **For Instance:** If the “Syncfusion.OfficeChart.Base” assembly (v15.2450.0.40) is referred to in the project, but the assembly version referred to by other Syncfusion assemblies is v15.2450.0.43. The Syncfusion Troubleshooter will display a mismatched Syncfusion assembly version.
+   **For Instance:** If the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .OfficeChart.Base” assembly (v15.2450.0.40) is referred to in the project, but the assembly version referred to by other  Syncfusion<sup style="font-size:70%">&reg;</sup>   assemblies is v15.2450.0.43. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display a mismatched  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly version.
 
-   ![Assembly version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img4.png)
+   ![Assembly version mismatched issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img4.png)
 
-3.	.NET Framework version mismatch (Syncfusion Assemblies) with project's .NET Framework version. The details for the supported .NET Framework for Syncfusion assemblies can be found at the following link.
+3.	.NET Framework version mismatch ( Syncfusion<sup style="font-size:70%">&reg;</sup>   Assemblies) with project's .NET Framework version. The details for the supported .NET Framework for  Syncfusion<sup style="font-size:70%">&reg;</sup>   assemblies can be found at the following link.
 
    <https://help.syncfusion.com/common/essential-studio/assembly-information#supported-framework-version-for-essential-studio-assemblies> 
 
-   **For Instance:** The application's .NET Framework is v4.6, and the "Syncfusion.EJ.PdfViewer" assembly (v16.4400.0.42 & .NET Framework version 4.0) is referred to in the same application. The Syncfusion Troubleshooter will indicate that the Syncfusion assembly's .NET Framework version is incompatible with the project's .NET Framework version.
+   **For Instance:** The application's .NET Framework is v4.6, and the " Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.PdfViewer" assembly (v16.4400.0.42 & .NET Framework version 4.0) is referred to in the same application. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will indicate that the  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly's .NET Framework version is incompatible with the project's .NET Framework version.
 
-   ![Target Framework version of application](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img5.png)
+   ![Target Framework version of application]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img5.png)
 
-   ![Framework mismatch issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img6.png)
+   ![Framework mismatch issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img6.png)
 
 ### NuGet issues
 
-The Syncfusion Troubleshooter handles the following NuGet package issues in Syncfusion projects.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter handles the following NuGet package issues in  Syncfusion<sup style="font-size:70%">&reg;</sup>   projects.
 
-1. Syncfusion NuGet Packages are installed in multiple versions. If one Syncfusion NuGet Package version differs from another, the Syncfusion Troubleshooter will indicate that the Syncfusion NuGet package version is mismatched.
+1.  Syncfusion<sup style="font-size:70%">&reg;</sup>   NuGet Packages are installed in multiple versions. If one  Syncfusion<sup style="font-size:70%">&reg;</sup>   NuGet Package version differs from another, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will indicate that the  Syncfusion<sup style="font-size:70%">&reg;</sup>   NuGet package version is mismatched.
 
-   **For Instance:** If you have multiple versions of the Syncfusion Web platform packages installed (v16.4.0.54 and v17.1.0.38), the Syncfusion Troubleshooter will display Syncfusion package version mismatch.
+   **For Instance:** If you have multiple versions of the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Web platform packages installed (v16.4.0.54 and v17.1.0.38), the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display  Syncfusion<sup style="font-size:70%">&reg;</sup>   package version mismatch.
  
-   ![Syncfusion NuGet Packages version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img7.png)
+   ![ Syncfusion  NuGet Packages version mismatched issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img7.png)
 
-2. Dependent NuGet package of the installed Syncfusion NuGet packages is missing.
+2. Dependent NuGet package of the installed  Syncfusion<sup style="font-size:70%">&reg;</sup>   NuGet packages is missing.
 
-   **For Instance:** If you install the Syncfusion Web NuGet package in your project without any dependencies, the Syncfusion Troubleshooter will report that the Syncfusion.Compression.Base and other dependent NuGet packages are missing.
+   **For Instance:** If you install the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Web NuGet package in your project without any dependencies, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will report that the  Syncfusion<sup style="font-size:70%">&reg;</sup>  .Compression.Base and other dependent NuGet packages are missing.
  
-   ![Dependent NuGet package missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img8.png)
+   ![Dependent NuGet package missing issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img8.png)
 
    I> To restore the missing dependent packages, an Internet connection is required. The dependent packages will not be restored if the internet is not available.
 
 ### Web.config issues
 
-The Syncfusion Troubleshooter handles with Web.config entry-related issues in Syncfusion projects.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter handles with Web.config entry-related issues in  Syncfusion<sup style="font-size:70%">&reg;</sup>   projects.
 
-1. The version of the Syncfusion assembly entry was mismatched. Each Syncfusion assembly entry version/.NET Framework version will be compared to the application's corresponding referred Syncfusion assembly.
+1. The version of the  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly entry was mismatched. Each  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly entry version/.NET Framework version will be compared to the application's corresponding referred  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly.
 
-   **For Instance:** If the “Syncfusion.EJ.Pivot” assembly (v17.1450.0.38) is mentioned in the project, but the “Syncfusion.EJ.Pivot” assembly entry version (v16.4450.0.54) is mentioned in the Web.config file. The Syncfusion Troubleshooter will display a mismatched Syncfusion assembly entry version.
+   **For Instance:** If the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.Pivot” assembly (v17.1450.0.38) is mentioned in the project, but the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.Pivot” assembly entry version (v16.4450.0.54) is mentioned in the Web.config file. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display a mismatched  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly entry version.
  
-   ![Syncfusion Toolbox Framework version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img9.png)
+   ![ Syncfusion   Toolbox Framework version mismatched issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img9.png)
 
-2. Syncfusion assembly entry has multiple versions and is duplicated. When a Syncfusion assembly entry is presented in Web.config that is not referred to in the project, or when multiple Syncfusion assembly entries are presented in Web.config for the same Syncfusion assembly, Syncfusion Troubleshooter will display the duplicate assembly entry.
+2.  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly entry has multiple versions and is duplicated. When a  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly entry is presented in Web.config that is not referred to in the project, or when multiple  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly entries are presented in Web.config for the same  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly,  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display the duplicate assembly entry.
 
-   **For Instance:** If the project contains a “Syncfusion.EJ.Web” assembly (v17.1450.0.38) entry in the Web.config file, but the “Syncfusion.EJ.Web” assembly is not referred to in the project. Duplicate assembly entry will be displayed by Syncfusion Troubleshooter.
+   **For Instance:** If the project contains a “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.Web” assembly (v17.1450.0.38) entry in the Web.config file, but the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.Web” assembly is not referred to in the project. Duplicate assembly entry will be displayed by  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter.
  
-   ![Duplicate Syncfusion reference assembly entry issue shown in Troubleshooter wizard ](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img10.png)
+   ![Duplicate  Syncfusion   reference assembly entry issue shown in Troubleshooter wizard ]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img10.png)
 
-   **For Instance:** If a project contains multiple “Syncfusion.EJ.Web” assembly entries (v16.4460.0.54 && v17.1460.0.38) with mismatched assembly version/.NET Framework version in Web.config, Syncfusion Troubleshooter will display the Duplicate assembly entry and Multiple Syncfusion assembly entries.
+   **For Instance:** If a project contains multiple “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.Web” assembly entries (v16.4460.0.54 && v17.1460.0.38) with mismatched assembly version/.NET Framework version in Web.config,  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display the Duplicate assembly entry and Multiple  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly entries.
 
-   ![Multiple version Syncfusion reference assembly entry issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img11.png)
+   ![Multiple version  Syncfusion  reference assembly entry issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img11.png)
 
-3. The version of the namespace entry was mismatched. If any Namespace entry version (assembly version) in ASP.NET Web Application is mismatched with the corresponding referred assembly version, Syncfusion Troubleshooter will display Namespace entry version mismatched.
+3. The version of the namespace entry was mismatched. If any Namespace entry version (assembly version) in ASP.NET Web Application is mismatched with the corresponding referred assembly version,  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display Namespace entry version mismatched.
 
-   **For Instance:** If the “Syncfusion.EJ” assembly (v17.1450.0.38) is referenced in the project and the “Syncfusion.JavaScript.DataVisualization” Namespace entry version (v16.4450.0.54) is referenced in the Web.config file. The Syncfusion Troubleshooter will display a mismatched Syncfusion namespace entry version.
+   **For Instance:** If the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ” assembly (v17.1450.0.38) is referenced in the project and the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .JavaScript.DataVisualization” Namespace entry version (v16.4450.0.54) is referenced in the Web.config file. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display a mismatched  Syncfusion<sup style="font-size:70%">&reg;</sup>   namespace entry version.
    
-   ![Namespace entry missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img12.png)
+   ![Namespace entry missing issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img12.png)
 
-4. Mismatch HTTP/Server handler entry. If any Syncfusion HTTP/Server handler entry version is mismatched when compared to the corresponding referred assembly version in the project, the Syncfusion Troubleshooter will show HTTP/Server handler entry mismatched.
+4. Mismatch HTTP/Server handler entry. If any  Syncfusion<sup style="font-size:70%">&reg;</sup>   HTTP/Server handler entry version is mismatched when compared to the corresponding referred assembly version in the project, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will show HTTP/Server handler entry mismatched.
 
-   **For Instance:** If the “Syncfusion.EJ.” assembly (v17.1450.0.38) is mentioned in the project, but the “Syncfusion.JavaScript.ImageHandler” HTTP/Server handler entry version (v16.4450.0.54) is specified in the Web.config file. The Syncfusion Troubleshooter will display a mismatched Syncfusion HTTP/Server handler entry version.
+   **For Instance:** If the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .EJ.” assembly (v17.1450.0.38) is mentioned in the project, but the “ Syncfusion<sup style="font-size:70%">&reg;</sup>  .JavaScript.ImageHandler” HTTP/Server handler entry version (v16.4450.0.54) is specified in the Web.config file. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display a mismatched  Syncfusion<sup style="font-size:70%">&reg;</sup>   HTTP/Server handler entry version.
    
-   ![Syncfusion HTTP/Server handler entry mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img13.png)
+   ![ Syncfusion  HTTP/Server handler entry mismatched issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img13.png)
 
 ### Toolbox Configuration Issues
 
-The Syncfusion Troubleshooter handles the Toolbox Configuration issues listed below in Syncfusion projects.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter handles the Toolbox Configuration issues listed below in  Syncfusion<sup style="font-size:70%">&reg;</sup>   projects.
 
-1. If the project's .NET Framework version is not installed/configured, the Syncfusion Troubleshooter will report that the Syncfusion Toolbox .NET Framework version is mismatched.
+1. If the project's .NET Framework version is not installed/configured, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will report that the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox .NET Framework version is mismatched.
 
-   **For Instance:** The .NET Framework version of the project is 4.5, and Syncfusion Toolbox is not installed. 4.6 framework assemblies only in the corresponding Visual Studio, the Syncfusion Troubleshooter will display Syncfusion Toolbox framework version mismatch.
+   **For Instance:** The .NET Framework version of the project is 4.5, and  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox is not installed. 4.6 framework assemblies only in the corresponding Visual Studio, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox framework version mismatch.
  
-   ![Syncfusion Toolbox Framework version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img14.png)
+   ![ Syncfusion   Toolbox Framework version mismatched issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img14.png)
 
-2. If the configured version of Syncfusion Toolbox differs from the most recent Syncfusion assembly reference version or NuGet package version in the same project, the Syncfusion Troubleshooter will indicate that the Syncfusion Toolbox version is mismatch.
+2. If the configured version of  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox differs from the most recent  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly reference version or NuGet package version in the same project, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will indicate that the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox version is mismatch.
 
-   **For Instance:** If the most recent Syncfusion assembly reference version is v17.1.0.38 but the Toolbox assemblies are configured with v17.1.0.32, the Syncfusion Troubleshooter will report Syncfusion Toolbox version mismatch.
+   **For Instance:** If the most recent  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly reference version is v17.1.0.38 but the Toolbox assemblies are configured with v17.1.0.32, the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will report  Syncfusion<sup style="font-size:70%">&reg;</sup>   Toolbox version mismatch.
   
-   ![Syncfusion Toolbox version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img15.png)
+   ![ Syncfusion   Toolbox version mismatched issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img15.png)
 
 ### Script file issues
 
-The Syncfusion Troubleshooter handles the following Script file issues in Syncfusion projects.
+The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter handles the following Script file issues in  Syncfusion<sup style="font-size:70%">&reg;</sup>   projects.
 
-1. The version of the Syncfusion script file is mismatch. Each Syncfusion script file version will be compared to the latest version of the corresponding referred Syncfusion assembly in the application.
+1. The version of the  Syncfusion<sup style="font-size:70%">&reg;</sup>   script file is mismatch. Each  Syncfusion<sup style="font-size:70%">&reg;</sup>   script file version will be compared to the latest version of the corresponding referred  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly in the application.
 
-   **For Instance:** If Syncfusion assemblies (v17.1450.0.38) and Syncfusion script file (v16.4.0.54) are referenced in the project. The Syncfusion Troubleshooter will display a Syncfusion script file version (v16.4.0.54) that is incompatible with the project's/package version of Syncfusion (v17.1.0.38).
+   **For Instance:** If  Syncfusion<sup style="font-size:70%">&reg;</sup>   assemblies (v17.1450.0.38) and  Syncfusion<sup style="font-size:70%">&reg;</sup>   script file (v16.4.0.54) are referenced in the project. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display a  Syncfusion<sup style="font-size:70%">&reg;</sup>   script file version (v16.4.0.54) that is incompatible with the project's/package version of  Syncfusion<sup style="font-size:70%">&reg;</sup>   (v17.1.0.38).
  
-   ![Syncfusion script file version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img16.png)
+   ![ Syncfusion  script file version mismatched issue shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img16.png)
 
-   **For Instance:** If Syncfusion assemblies (v17.1450.0.38) are referred to in the project, but Syncfusion script file version (v16.4.0.54) is referred to in View files when script files are referred to via a CDN link. The Syncfusion Troubleshooter will report that the Syncfusion script file version (v16.4.0.54) is incompatible with the project's Syncfusion assembly/package version (v17.1.0.38) from CDN.
+   **For Instance:** If  Syncfusion<sup style="font-size:70%">&reg;</sup>   assemblies (v17.1450.0.38) are referred to in the project, but  Syncfusion<sup style="font-size:70%">&reg;</sup>   script file version (v16.4.0.54) is referred to in View files when script files are referred to via a CDN link. The  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will report that the  Syncfusion<sup style="font-size:70%">&reg;</sup>   script file version (v16.4.0.54) is incompatible with the project's  Syncfusion<sup style="font-size:70%">&reg;</sup>   assembly/package version (v17.1.0.38) from CDN.
 
-   ![Syncfusion script file version mismatched issue based on CDN link shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img17.png)
+   ![ Syncfusion  script file version mismatched issue based on CDN link shown in Troubleshooter wizard]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img17.png)
 
-2. Syncfusion script files that are duplicates. When a Syncfusion script file is presented in the project location, which is referred to in View files by CDN link, or when Syncfusion script files are presented in multiple locations in the same project, Syncfusion Troubleshooter will display duplicate script files.
+2.  Syncfusion<sup style="font-size:70%">&reg;</sup>   script files that are duplicates. When a  Syncfusion<sup style="font-size:70%">&reg;</sup>   script file is presented in the project location, which is referred to in View files by CDN link, or when  Syncfusion<sup style="font-size:70%">&reg;</sup>   script files are presented in multiple locations in the same project,  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display duplicate script files.
 
-   **For Instance:** If the project has a “ej.web.all.min.js” script file entry in the View file and a “ej.web.all.min.js” script file in the project location (Scripts\ej), the Syncfusion Troubleshooter will show duplicate Syncfusion script files presented in Scripts\ej due to this script file being referred from CDN.
+   **For Instance:** If the project has a “ej.web.all.min.js” script file entry in the View file and a “ej.web.all.min.js” script file in the project location (Scripts\ej), the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will show duplicate  Syncfusion<sup style="font-size:70%">&reg;</sup>   script files presented in Scripts\ej due to this script file being referred from CDN.
   
-   ![Syncfusion script file duplicate issue by CDN with local script](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img18.png)
+   ![ Syncfusion  script file duplicate issue by CDN with local script]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img18.png)
 
-   **For Instance:** If a project has the “ej.web.all.min.js” script file available in multiple project locations ("\Scripts\ej" and "\Scripts\"), the Syncfusion Troubleshooter will display Duplicate Syncfusion script files in Scripts.
+   **For Instance:** If a project has the “ej.web.all.min.js” script file available in multiple project locations ("\Scripts\ej" and "\Scripts\"), the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter will display Duplicate  Syncfusion<sup style="font-size:70%">&reg;</sup>   script files in Scripts.
   
-   ![Syncfusion script file duplicate issue by mulitple location ](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img19.png)
+   ![ Syncfusion  script file duplicate issue by mulitple location ]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img19.png)
 
 ## Apply the solution
 
-1. Check the corresponding check box of the issue to be resolved after loading the Syncfusion Troubleshooter dialog. Then, check “Fix Issue(s)” button.
+1. Check the corresponding check box of the issue to be resolved after loading the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter dialog. Then, check “Fix Issue(s)” button.
 
-   ![Syncfusion Troubleshooter wizard with project configuration issues](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img20.png)
+   ![ Syncfusion  Troubleshooter wizard with project configuration issues]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img20.png)
 
 2. A dialog appears, prompting you to create a backup of the project before proceeding with the troubleshooting process. Click the "Yes" button if you need to backup the project before troubleshooting.
 
-   ![Syncfusion Troubleshooter backup dialog](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img21.jpeg)
+   ![ Syncfusion  Troubleshooter backup dialog]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img21.jpeg)
 
-3. Wait a moment while the Syncfusion Troubleshooter resolves the issues you selected. When the troubleshooting process is finished, a message will appear in the Visual Studio status bar that says, "Troubleshooting process completed successfully."
+3. Wait a moment while the  Syncfusion<sup style="font-size:70%">&reg;</sup>   Troubleshooter resolves the issues you selected. When the troubleshooting process is finished, a message will appear in the Visual Studio status bar that says, "Troubleshooting process completed successfully."
 
-   ![Syncfusion Troubleshooter process success status message in visual studio status bar](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img22.jpeg)
+   ![ Syncfusion  Troubleshooter process success status message in visual studio status bar]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img22.jpeg)
 
-4. Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.   
+4. Then,  Syncfusion<sup style="font-size:70%">&reg;</sup>   licensing registration required message box will be shown if you installed the trial setup or NuGet packages since  Syncfusion<sup style="font-size:70%">&reg;</sup>   introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the  Syncfusion<sup style="font-size:70%">&reg;</sup>   license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.   
 
-   ![Syncfusion license registration required information dialog in Syncfusion Troubleshooter](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img23.jpeg)
+   ![ Syncfusion  license registration required information dialog in  Syncfusion  Troubleshooter]( Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter_images/ Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter-img23.jpeg)

--- a/Extension/ASPNET-MVC-Extension/Command-Line-installation.md
+++ b/Extension/ASPNET-MVC-Extension/Command-Line-installation.md
@@ -3,13 +3,13 @@ layout: post
 title: Command Line installation | Extension | Syncfusion
 description: command line installation
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Command Line installation
 
-The following steps help you install the Syncfusion Web Sample Creator setup through Command Line in Silent mode.
+The following steps help you install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator setup through Command Line in Silent mode.
 
 1. Double-click the Syncfusion Web Sample Creator Setup file. The Self-Extractor Wizard opens and extracts the package automatically.
 2. The syncfusionwebsamplecreator.exe file is extracted into the Temp folder.
@@ -24,6 +24,6 @@ The following steps help you install the Syncfusion Web Sample Creator setup thr
 
    Refer to the following screenshot for more information.
 
-   ![Command line arguments to install Syncfusion web sample creator from command prompt](Command-Line-installation_images/Command-Line-installation-img1.png)
+   ![Command line arguments to install Syncfusion<sup style="font-size:70%">&reg;</sup>  web sample creator from command prompt](Command-Line-installation_images/Command-Line-installation-img1.png)
 
 I> The syncfusionessentialextension.exe setup has renamed to syncfusionwebsamplecreator.exe from 2015 Volume 4 release.

--- a/Extension/ASPNET-MVC-Extension/Download-ASPNET-MVC-Extension.md
+++ b/Extension/ASPNET-MVC-Extension/Download-ASPNET-MVC-Extension.md
@@ -1,27 +1,27 @@
 ---
 layout: post
 title: Download ASPNET MVC Extension | Extension | Syncfusion
-description: Learn here about download asp.net mvc extension in Syncfusion Essential ASP.NET MVC Extension Control, its elements, and more.
+description: Learn here about download asp.net mvc extension in Syncfusion  Essential ASP.NET MVC Extension Control, its elements, and more.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion<sup style="font-size:70%">&reg;</sup>  Extensions
 documentation: ug
 ---
 
-# Download Syncfusion Web Sample Creator 
+# Download Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator 
 
-1. Download the latest Syncfusion Web Sample Creator setup from the following location: [https://www.syncfusion.com/downloads/extension](https://www.syncfusion.com/downloads/extension)
+1. Download the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator setup from the following location: [https://www.syncfusion.com/downloads/extension](https://www.syncfusion.com/downloads/extension)
 
    Refer the following screenshot for more information.
 
-   ![Download link for Syncfusion Essential Studio Web Sample Creator](Download-ASPNET-MVC-Extension_images/Download-ASPNET-MVC-Extension-img1.jpeg)
+   ![Download link for Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  Web Sample Creator](Download-ASPNET-MVC-Extension_images/Download-ASPNET-MVC-Extension-img1.jpeg)
 
-   I> It is a prerequisite to have the complete Essential Studio suite or ASP.NET MVC or ASP.NET MVC (Classic) installed while using Syncfusion ASP.NET MVC Extension. This is applicable from v.12.1.0.43.
+   I> It is a prerequisite to have the complete Essential Studio<sup style="font-size:70%">&reg;</sup>  suite or ASP.NET MVC or ASP.NET MVC (Classic) installed while using Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Extension. This is applicable from v.12.1.0.43.
 
-2. You can download the corresponding syncfusionwebsamplecreator.exe Version directly from the Syncfusion Dashboard. After installing the complete Essential Studio suite or ASP.NET MVC or ASP.NET MVC (Classic) setup, follow the given steps:
+2. You can download the corresponding syncfusionwebsamplecreator.exe Version directly from the Syncfusion<sup style="font-size:70%">&reg;</sup>  Dashboard. After installing the complete Essential Studio<sup style="font-size:70%">&reg;</sup>  suite or ASP.NET MVC or ASP.NET MVC (Classic) setup, follow the given steps:
 
-   * Launch the Syncfusion Dashboard 
+   * Launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  Dashboard 
    * Navigate to the “ASP.NET MVC” tab available on the left side.
-   * Click the “SAMPLE CREATOR” button. It downloads the corresponding version of Syncfusion Web Sample Creator setup. When you have already installed the Syncfusion Web Sample Creator setup then it will launch the “Sample Creator” utility instead of downloading. 
+   * Click the “SAMPLE CREATOR” button. It downloads the corresponding version of Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator setup. When you have already installed the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator setup then it will launch the “Sample Creator” utility instead of downloading. 
 
     ![Syncfusion Essential studio control panel to launch the Sample Creator](Download-ASPNET-MVC-Extension_images/Download-ASPNET-MVC-Extension-img2.jpeg)
 

--- a/Extension/ASPNET-MVC-Extension/Overview.md
+++ b/Extension/ASPNET-MVC-Extension/Overview.md
@@ -1,25 +1,25 @@
 ---
 layout: post
 title: ASP.NET MVC (Essential JS 1) Extension | Extension | Syncfusion
-description: An Extension provides you with quick access so that you can create or configure the Syncfusion ASP.NET MVC projects along with Essential JS 1 components
+description: An Extension provides you with quick access so that you can create or configure the Syncfusion  ASP.NET MVC projects along with Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # ASPNET MVC Extension
 
-The Syncfusion ASP.NET MVC (Essential JS 1) Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.The Syncfusion MVC Extension supports Microsoft Visual Studio 2010 or higher.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup> JS 1) Visual Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.The Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Extension supports Microsoft Visual Studio 2010 or higher.
 
-I> The Syncfusion ASP.NET MVC (Essential JS 1) menu option is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup> JS 1) menu option is available from v17.1.0.32.
 
-The Syncfusion provides the following extension supports in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the following extension supports in Visual Studio:
 
-1.	[Syncfusion ASP.NET MVC (Essential JS 1) Project Template](https://help.syncfusion.com/extension/aspnet-mvc-extension/syncfusion-project-templates): To create the Syncfusion ASP.NET MVC (Essential JS 1) or ASP.NET MVC (Classic) application by adding the required Essential JS 1 components.
-2.	[Project Conversion](https://help.syncfusion.com/extension/aspnet-mvc-extension/project-conversion): To convert an existing ASP.NET MVC application into a Syncfusion ASP.NET MVC (Essential JS 1) or ASP.NET MVC (Classic) application by adding the required Syncfusion assemblies and resource files.
-3.	[Migrate Project](https://help.syncfusion.com/extension/aspnet-mvc-extension/project-migration): Migrate the existing Syncfusion ASP.NET MVC or ASP.NET MVC (Classic) application from one Essential Studio version to another version.
-4.	[Sample Creator](https://help.syncfusion.com/extension/aspnet-mvc-extension/sample-creator): Create the Syncfusion ASP.NET MVC (Essential JS 1) or ASP.NET MVC (Classic) Projects with the required Syncfusion configuration to start development with the required Syncfusion controls.
-5.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the Syncfusion configuration and apply the fix like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly.
+1.	[Syncfusion ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup> JS 1) Project Template](https://help.syncfusion.com/extension/aspnet-mvc-extension/syncfusion-project-templates): To create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) or ASP.NET MVC (Classic) application by adding the required Essential JS 1 components.
+2.	[Project Conversion](https://help.syncfusion.com/extension/aspnet-mvc-extension/project-conversion): To convert an existing ASP.NET MVC application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) or ASP.NET MVC (Classic) application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and resource files.
+3.	[Migrate Project](https://help.syncfusion.com/extension/aspnet-mvc-extension/project-migration): Migrate the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC or ASP.NET MVC (Classic) application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.
+4.	[Sample Creator](https://help.syncfusion.com/extension/aspnet-mvc-extension/sample-creator): Create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) or ASP.NET MVC (Classic) Projects with the required Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration to start development with the required Syncfusion<sup style="font-size:70%">&reg;</sup>  controls.
+5.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration and apply the fix like, wrong Framework Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly added to the project or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly.
 
 **No project selected in Visual Studio**
 
@@ -29,11 +29,11 @@ The Syncfusion provides the following extension supports in Visual Studio:
 
 ![Syncfusion Menu when Selected Microsoft ASP.NET MVC application in Visual Studio](Overview-images/Syncfusion_Menu_OverView2.png)
 
-**Selected Syncfusion ASP.NET MVC (Essential JS1) application in Visual Studio**
+**Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS1) application in Visual Studio**
 
 ![Syncfusion Menu when Selected Synfusion ASP.NET MVC EJ1 application in Visual Studio](Overview-images/Syncfusion_Menu_OverView3.png)
 
-N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
 
 

--- a/Extension/ASPNET-MVC-Extension/Project-Conversion.md
+++ b/Extension/ASPNET-MVC-Extension/Project-Conversion.md
@@ -1,27 +1,27 @@
 ---
 layout: post
 title: Project Conversion | ASP.NET MVC (Essential JS 1) | Syncfusion
-description: Project Conversion is a add-in that converts an existing ASP.NET MVC Project into a Syncfusion ASP.NET MVC Project by adding required Essential JS 1 components
+description: Project Conversion is a add-in that converts an existing ASP.NET MVC Project into a Syncfusion  ASP.NET MVC Project by adding required Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # ASP.NET MVC Project Conversion
 
-Project Conversion is a Visual Studio add-in that converts an existing ASP.NET MVC Project into a Syncfusion ASP.NET MVC Project by adding the required assemblies and resource files.
+Project Conversion is a Visual Studio add-in that converts an existing ASP.NET MVC Project into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project by adding the required assemblies and resource files.
 
 Syncfusion ASP.NET MVC and ASP.NET MVC (Classic) Project Conversion Utility is included here,
 
-* Essential Studio for Enterprise Edition with the platforms ASP.NETMVC or ASP.NET MVC(Classic)
-* Essential Studio for ASP.NET MVC
-* Essential Studio for ASP.NET MVC (Classic)
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platforms ASP.NETMVC or ASP.NET MVC(Classic)
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC (Classic)
 
-I>  The Project conversion Visual Studio add-in is available from the v11.1.0.21 and this is not applicable from v.12.1.0.43 to v.13.1.0.30. The Syncfusion ASP.NET MVC (Web) and ASP.NET MVC (Classic) Project Conversion Utilities are excluded from the MVC Extension setup and integrated into Essential Studio ASP.NET MVC and ASP.NET MVC (Classic) platforms.
+I>  The Project conversion Visual Studio add-in is available from the v11.1.0.21 and this is not applicable from v.12.1.0.43 to v.13.1.0.30. The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Web) and ASP.NET MVC (Classic) Project Conversion Utilities are excluded from the MVC Extension setup and integrated into Essential Studio<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC and ASP.NET MVC (Classic) platforms.
 
 ## ASP.NET MVC (Classic) Conversion\Migration:
 
-By default, the Syncfusion ASP.NET MVC Extensions are configured in Visual Studio. When you want the ASP.NET MVC (Classic) extension, you can install it from the installed location.
+By default, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Extensions are configured in Visual Studio. When you want the ASP.NET MVC (Classic) extension, you can install it from the installed location.
 
 ### Project Conversion and Migration (ASP.NET MVC(Classic):
 
@@ -29,25 +29,25 @@ Location : `{Drive}\Program Files (x86)\Syncfusion\Essential Studio\<Version>\U
     
 For Example - VS2013 : `C:\Program Files (x86)\Syncfusion\Essential Studio\13.2.0.18\Utilities\Extensions\ASP.NET MVC\Project Conversion\4.5.1\Syncfusion Web (Classic) Conversion and Migration.vsix`
 
-## Convert into Syncfusion MVC (Web) project
+## Convert into Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC (Web) project
 
-The following steps help you use the Syncfusion Project Conversion in the existing ASP.NET MVC (Web) Project.
+The following steps help you use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion in the existing ASP.NET MVC (Web) Project.
 
-> Before use, the Syncfusion ASP.NET MVC (Essential JS 1) Project Conversion, check whether the **Syncfusion Essential JS1 AspNet MVC VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Conversion will not be shown.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) Project Conversion, check whether the **Syncfusion Essential JS1 AspNet MVC VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Conversion will not be shown.
 
 1. Open an existing Microsoft MVC Project or create a new Microsoft MVC Project.
 
 2. To open Project Conversion Wizard, follow either one of the options below: 
 
    **Option 1:**  
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC (EJ1) > Convert to Syncfusion ASP.NET MVC Application…** in **Visual Studio**.
+   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC (EJ1) > Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Application…** in **Visual Studio**.
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Web Project Conversion via Synfusion menu](Convert-into-Syncfusion-MVC-project_images/Syncfusion_Menu_Project_Conversion.png)
 
-   N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**  
-   Right-click the Project from Solution Explorer, select **Syncfusion Essential JS 1**, and choose **Convert to Syncfusion MVC (Essential JS 1) Application...** Refer to the following screenshot for more information.
+   Right-click the Project from Solution Explorer, select **Syncfusion Essential JS 1**, and choose **Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC (Essential JS 1) Application...** Refer to the following screenshot for more information.
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Web Project Conversion add-in](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img1.png)
 
@@ -62,22 +62,22 @@ The following steps help you use the Syncfusion Project Conversion in the existi
    Choose the assembly location:
 
 	1. Added From GAC - Refer the assemblies from the Global Assembly Cache
-	2. Added from Installed Location - Refer the assemblies from the Syncfusion Installed locations.
+	2. Added from Installed Location - Refer the assemblies from the Syncfusion<sup style="font-size:70%">&reg;</sup>  Installed locations.
    3. Add Referenced Assemblies to Solution - Copy and refer to the assemblies from project's solution file lib directory.
 
    ![Choose the assembly location from where assemblies to be referred to the ASP.NET MVC project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img3.jpeg)
     
    **Choose the Theme:**
    
-   The master page of project will be updated based on selected theme. The Theme Preview section shows the controls preview before convert into a Syncfusion project.
+   The master page of project will be updated based on selected theme. The Theme Preview section shows the controls preview before convert into a Syncfusion<sup style="font-size:70%">&reg;</sup>  project.
    
    ![Choose the theme to apply on the master page of the ASP.NET MVC project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img4.jpeg)
    
    **Choose CDN Support:**
 
-   The master page of the project will be updated based on required Syncfusion CDN links.
+   The master page of the project will be updated based on required Syncfusion<sup style="font-size:70%">&reg;</sup>  CDN links.
    
-   ![Choose CDN Support to refer the Syncfusion assets from CDN for ASP.NET MVC project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img20.jpeg)
+   ![Choose CDN Support to refer the Syncfusion<sup style="font-size:70%">&reg;</sup>  assets from CDN for ASP.NET MVC project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img20.jpeg)
    
    **Choose Copy Global Resources:**
     
@@ -85,16 +85,16 @@ The following steps help you use the Syncfusion Project Conversion in the existi
    
    ![Choose Copy Global Resources to ship the localization culture files for ASP.NET MVC project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img21.jpeg)
 
-4. Choose the required controls from Components section and Click the **Convert** button to convert it into a Syncfusion Project.
+4. Choose the required controls from Components section and Click the **Convert** button to convert it into a Syncfusion<sup style="font-size:70%">&reg;</sup>  Project.
 
-   ![Select the required components from the Components section in the Syncfusion ASP.NET MVC Project Conversion Wizard](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img5.jpg)
+   ![Select the required components from the Components section in the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project Conversion Wizard](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img5.jpg)
    
-5. The **Project Backup** dialog will be opened. If click Yes it will backup the current project before converting it to Syncfusion project. If click No it will convert the project to Syncfusion project without backup. 
+5. The **Project Backup** dialog will be opened. If click Yes it will backup the current project before converting it to Syncfusion<sup style="font-size:70%">&reg;</sup>  project. If click No it will convert the project to Syncfusion<sup style="font-size:70%">&reg;</sup>  project without backup. 
    
    ![Syncfusion Essential JS 1 ASP.NET MVC Web Project Conversion backup dialog](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img6.jpg)
 
 
-6. The required Syncfusion Reference Assemblies, Scripts and CSS are included in the MVC Project. Refer to the following screenshots for more information.
+6. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Assemblies, Scripts and CSS are included in the MVC Project. Refer to the following screenshots for more information.
 
    ![Syncfusion Essential JS 1 ASP.NET MVC scripts and themes](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img7.jpeg)
 
@@ -102,15 +102,15 @@ The following steps help you use the Syncfusion Project Conversion in the existi
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Web.config entries](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img9.jpeg)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
-## Convert into Syncfusion MVC (Mobile) project
+## Convert into Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC (Mobile) project
 
-The following steps help you use the Syncfusion Project Conversion in the existing ASP.NET MVC Project.
+The following steps help you use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion in the existing ASP.NET MVC Project.
 
 1. Open an existing Microsoft MVC Project or create a new Microsoft MVC Project.
 
-2. Right-click on Project and select Syncfusion VS Extensions and choose the Convert to Syncfusion MVC (Web) Application. Refer the following screenshot for more information.
+2. Right-click on Project and select Syncfusion<sup style="font-size:70%">&reg;</sup>  VS Extensions and choose the Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC (Web) Application. Refer the following screenshot for more information.
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Mobile Project Conversion add-in](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img10.jpeg)
 
@@ -125,7 +125,7 @@ The following steps help you use the Syncfusion Project Conversion in the existi
    Choose the assembly location:
 
 	1. Added From GAC - Refer the assemblies from the Global Assembly Cache
-	2. Added from Installed Location - Refer the assemblies from the Syncfusion Installed locations.
+	2. Added from Installed Location - Refer the assemblies from the Syncfusion<sup style="font-size:70%">&reg;</sup>  Installed locations.
    3. Add Referenced Assemblies to Solution - Copy and refer to the assemblies from project's solution file lib directory.   
 
    ![Choose the assembly location from where assemblies to be referred to the ASP.NET MVC Mobile project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img3.jpeg) 
@@ -138,9 +138,9 @@ The following steps help you use the Syncfusion Project Conversion in the existi
 	
    **Choose CDN Support:**
 
-   The master page of the project will be updated based on required Syncfusion CDN links.
+   The master page of the project will be updated based on required Syncfusion<sup style="font-size:70%">&reg;</sup>  CDN links.
    
-   ![Choose CDN Support to refer the Syncfusion assets from CDN for ASP.NET MVC Mobile project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img20.jpeg)
+   ![Choose CDN Support to refer the Syncfusion<sup style="font-size:70%">&reg;</sup>  assets from CDN for ASP.NET MVC Mobile project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img20.jpeg)
    
    **Choose Copy Global Resources:**
     
@@ -148,9 +148,9 @@ The following steps help you use the Syncfusion Project Conversion in the existi
    
    ![Choose Copy Global Resources to ship the localization culture files for ASP.NET MVC Mobile project](Convert-into-Syncfusion-MVC-project_images/Project-Conversion-img21.jpeg)
 
-4. Click the Convert button to convert it into a Syncfusion Project.
+4. Click the Convert button to convert it into a Syncfusion<sup style="font-size:70%">&reg;</sup>  Project.
 
-5. The required Syncfusion Reference Assemblies, Scripts and CSS are included in the MVC Project. Refer to the following screenshots for more information.
+5. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Assemblies, Scripts and CSS are included in the MVC Project. Refer to the following screenshots for more information.
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Mobile Project required reference assemblies](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img13.jpeg)
 
@@ -160,10 +160,10 @@ The following steps help you use the Syncfusion Project Conversion in the existi
 
    ![Syncfusion assembly reference entry in Webconfig file of the Essential JS 1 ASP.NET MVC Mobile Project](Convert-into-Syncfusion-MVC-project_images/ProjectConversion-img16.jpeg)
 
-## Rendering Control after Syncfusion MVC (Web/Mobile) Conversion:
+## Rendering Control after Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC (Web/Mobile) Conversion:
 
-Once you convert your ASP.NET MVC project to Syncfusion MVC Project, perform the following steps to render the Syncfusion Controls to your project.               
-1. The CSS, Scripts, Syncfusion References and required Web.config file entries are added to your project by Syncfusion ASP.NET MVC Conversion.  
+Once you convert your ASP.NET MVC project to Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Project, perform the following steps to render the Syncfusion Controls to your project.               
+1. The CSS, Scripts, Syncfusion<sup style="font-size:70%">&reg;</sup>  References and required Web.config file entries are added to your project by Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Conversion.  
 
 2. Add the required Script and CSS files references in the master page (_Layout.cshtml/Layout.vbhtml file). Please refer to below screenshot for more information.
 

--- a/Extension/ASPNET-MVC-Extension/Project-Migration.md
+++ b/Extension/ASPNET-MVC-Extension/Project-Migration.md
@@ -1,27 +1,27 @@
 ---
 layout: post
 title: Project Migration | ASP.NET MVC (Essential JS 1) | Syncfusion
-description: Project Migration is a add-in that helps migrate existing Syncfusion Essential JS 1 ASP.NET MVC project from one Syncfusion version to another version
+description: Project Migration is a add-in that helps migrate existing Syncfusion  Essential JS 1 ASP.NET MVC project from one Syncfusion  version to another version
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # ASP.NET MVC Project Migration
 
-Project Migration is a Visual Studio add-in that helps migrate the existing Syncfusion ASP.NET MVC (Web), Syncfusion ASP.NET MVC (Mobile) Or Syncfusion ASP.NET MVC (Classic) project from one Syncfusion version to another Syncfusion version.
+Project Migration is a Visual Studio add-in that helps migrate the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Web), Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Mobile) Or Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Classic) project from one Syncfusion<sup style="font-size:70%">&reg;</sup>  version to another Syncfusion<sup style="font-size:70%">&reg;</sup>  version.
 
 Syncfusion ASP.NET MVC and ASP.NET MVC (Classic) Project Migration Utility is included here,
 
-* Essential Studio for Enterprise Edition with the platforms ASP.NET MVC or ASP.NET MVC(Classic)
-* Essential Studio for ASP.NET MVC
-* Essential Studio for ASP.NET MVC (Classic)
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platforms ASP.NET MVC or ASP.NET MVC(Classic)
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC (Classic)
 
-I> This is not applicable from v.12.1.0.43 to v.13.1.0.30. The Syncfusion ASP.NET MVC and ASP.NET MVC (Classic) Project Migration Utilities are excluded from MVC Extension setup and integrated into Essential Studio ASP.NET MVC and ASP.NET MVC (Classic) platforms.
+I> This is not applicable from v.12.1.0.43 to v.13.1.0.30. The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC and ASP.NET MVC (Classic) Project Migration Utilities are excluded from MVC Extension setup and integrated into Essential Studio<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC and ASP.NET MVC (Classic) platforms.
 
 ## ASP.NET MVC (Classic) Conversion\Migration:
 
-By default, the Syncfusion ASP.NET MVC Extensions are configured in Visual Studio. When you want the ASP.NET MVC (Classic) extension, you can install it from the installed location.
+By default, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Extensions are configured in Visual Studio. When you want the ASP.NET MVC (Classic) extension, you can install it from the installed location.
 
 Project Conversion and Migration (ASP.NET MVC(Classic):
 
@@ -29,44 +29,44 @@ Location: `{Drive}\Program Files (x86)\Syncfusion\Essential Studio\<Version>\Ut
 
 For Example - VS2013: `C:\Program Files (x86)\Syncfusion\Essential Studio\13.2.0.18\Utilities\Extensions\ASP.NET MVC\Project Conversion\4.5.1\Syncfusion Web (Classic) Conversion and Migration.vsix`
 
-## Migrate Syncfusion MVC Project
+## Migrate Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Project
 
-The following steps help you migrate from one version to another version of your existing Syncfusion ASP.NET MVC application.
+The following steps help you migrate from one version to another version of your existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC application.
 
-> Before use, the Syncfusion ASP.NET MVC (Essential JS 1) Project Migration, check whether the **Syncfusion Essential JS1 AspNet MVC VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Migration will not be shown.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) Project Migration, check whether the **Syncfusion<sup style="font-size:70%">&reg;</sup> Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet MVC VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Migration will not be shown.
 
 1. To open Migration Wizard, follow either one of the options below: 
 
    **Option 1:**  
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC (EJ1) > Migrate Project…** in **Visual Studio**.
+   Click **Syncfusion<sup style="font-size:70%">&reg;</sup> Menu** and choose **Essential Studio<sup style="font-size:70%">&reg;</sup> for ASP.NET MVC (EJ1) > Migrate Project…** in **Visual Studio**.
 
-   ![Syncfusion Essential JS 1 ASP.NET MVC Project Migration via Syncfusion menu](Migrate-Syncfusion-Project_images/SyncfusionMenu_ProjectMigration_img.png)
+   ![Syncfusion Essential JS 1 ASP.NET MVC Project Migration via Syncfusion  menu](Migrate-Syncfusion-Project_images/SyncfusionMenu_ProjectMigration_img.png)
 
-   N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**  
-   Right-click the **Syncfusion ASP.NET MVC Application** from Solution Explorer and select **Syncfusion Essential JS 1**. Choose **Migrate the Essential JS 1 Project to Another Version...**
+   Right-click the **Syncfusion<sup style="font-size:70%">&reg;</sup> ASP.NET MVC Application** from Solution Explorer and select **Syncfusion<sup style="font-size:70%">&reg;</sup> Essential<sup style="font-size:70%">&reg;</sup> JS 1**. Choose **Migrate the Essential<sup style="font-size:70%">&reg;</sup> JS 1 Project to Another Version...**
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Project Migration add-in](Migrate-Syncfusion-Project_images/ProjectMigration_img.png)
 
-2. The Project Migration window appears. You can choose the required Syncfusion version that is installed in the machine that is either Syncfusion ASP.NET MVC or Syncfusion ASP.NET MVC (Classic).
+2. The Project Migration window appears. You can choose the required Syncfusion<sup style="font-size:70%">&reg;</sup>  version that is installed in the machine that is either Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC or Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Classic).
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Project Migration wizard](Migrate-Syncfusion-Project_images/ProjectMigration-img2.jpeg)
 
 3. The Project Migration window allows you to configure the following options:
 
-   * Essential Studio Version: Select any version from the list of Installed Versions.
+   * Essential Studio<sup style="font-size:70%">&reg;</sup>  Version: Select any version from the list of Installed Versions.
 	  
    * Assemblies From: The option Assemblies from add the assembly to project from the following locations.
 	  
 	    1. Added From GAC - Refer the assemblies from the Global Assembly Cache
-		2. Added from Installed Location - Refer the assemblies from the Syncfusion Installed locations.
+		2. Added from Installed Location - Refer the assemblies from the Syncfusion<sup style="font-size:70%">&reg;</sup>  Installed locations.
         3. Add Referenced Assemblies to Solution - Copy and refer to the assemblies from project's solution file lib directory.  
 
-4. Click the Migrate Button. The **Project Backup** dialog will be opened. If click Yes it will backup the current project before migrate the Syncfusion project. If click No it will migrate the project to required Syncfusion version without backup. 
+4. Click the Migrate Button. The **Project Backup** dialog will be opened. If click Yes it will backup the current project before migrate the Syncfusion<sup style="font-size:70%">&reg;</sup>  project. If click No it will migrate the project to required Syncfusion<sup style="font-size:70%">&reg;</sup>  version without backup. 
 
      ![Syncfusion Essential JS 1 ASP.NET MVC Project Migration backup dialog](Migrate-Syncfusion-Project_images/ProjectMigration-img3.jpeg)
       
-5. The Syncfusion Reference Assemblies, Scripts and CSS are updated to the corresponding version in the project.
+5. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Assemblies, Scripts and CSS are updated to the corresponding version in the project.
 
-6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.

--- a/Extension/ASPNET-MVC-Extension/Sample-Creator.md
+++ b/Extension/ASPNET-MVC-Extension/Sample-Creator.md
@@ -1,41 +1,41 @@
 ---
 layout: post
 title: Sample Creator | ASP.NET MVC (Essential JS 1) | Syncfusion
-description: Sample Creator is the utility that allows you to create Syncfusion ASP.NET MVC Projects along with the samples based on Controls and Features selection
+description: Sample Creator is the utility that allows you to create Syncfusion  ASP.NET MVC Projects along with the samples based on Controls and Features selection
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Sample Creator in ASP.NET MVC Extensions
 
-Sample Creator is the utility that allows you to create Syncfusion ASP.NET MVC/Syncfusion ASP.NET MVC (Classic) Projects along with the samples based on Controls and Features selection.
+Sample Creator is the utility that allows you to create Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC/Syncfusion ASP.NET MVC (Classic) Projects along with the samples based on Controls and Features selection.
 
-## Create Syncfusion MVC Project from Sample Creator
+## Create Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Project from Sample Creator
 
-The following steps help you to create the Syncfusion ASP.NET MVC Project via the Sample Creator utility.
+The following steps help you to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project via the Sample Creator utility.
 
-1. To launch ASP.NET MVC (Essential JS 1) Sample Creator application, follow either one of the options below: 
+1. To launch ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup> JS 1) Sample Creator application, follow either one of the options below: 
 
    **Option 1:**  
    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC (EJ1) > Launch Sample Creator…** in **Visual Studio**.
 
-   ![launch the Essential JS 1 ASP.NET MVC Sample Creator via Syncfusion menu](Sample-Creator_images/Syncfusion_Menu_SampleCreator.png)
+   ![launch the Essential JS 1 ASP.NET MVC Sample Creator via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Sample-Creator_images/Syncfusion_Menu_SampleCreator.png)
 
-   N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**  
-   Launch the Syncfusion Essential Studio Dashboard and select the ASP.NET MVC (Essential JS 1)/ASP.NET MVC (Classic) platform. Select the Sample Creator button to launch the ASP.NET MVC (Essential JS 1) Sample Creator application. Refer to the following screenshot for more information.
+   Launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  Dashboard and select the ASP.NET MVC (Essential JS 1)/ASP.NET MVC (Classic) platform. Select the Sample Creator button to launch the ASP.NET MVC (Essential JS 1) Sample Creator application. Refer to the following screenshot for more information.
  
-   ![Syncfusion Essential Studio control panel to launch the Essential JS 1 ASP.NET MVC Sample Creator](Sample-Creator_images/Sample-Creator-img1.png)
+   ![Syncfusion Essential Studio<sup style="font-size:70%">&reg;</sup>  control panel to launch the Essential JS 1 ASP.NET MVC Sample Creator](Sample-Creator_images/Sample-Creator-img1.png)
 
-2. Syncfusion Sample Creator Wizard displaying the **Controls and its Feature Selection** section. 
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  Sample Creator Wizard displaying the **Controls and its Feature Selection** section. 
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Sample Creator Wizard](Sample-Creator_images/Sample-Creator-img2.jpeg)
 
 ### Controls Selection
 
- Listed here are the Syncfusion ASP.NET MVC controls so you can choose the required controls. And the controls are grouped product wise.
+ Listed here are the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC controls so you can choose the required controls. And the controls are grouped product wise.
 
  ![Syncfusion Essential JS 1 ASP.NET MVC Sample Creator Controls Selection](Sample-Creator_images/Sample-Creator-img3.png)
 
@@ -53,33 +53,33 @@ You can configure the following project details in the Sample Creator.
 * Language – Select the language, either C# or VB.
 * VS Version – Choose the Project version
 * .NET Framework – Choose the .NET Framework version.
-* View Engine – Select either Razor or ASPX. By default, Syncfusion supports only Razor view engine for ASP.NET MVC projects.
+* View Engine – Select either Razor or ASPX. By default, Syncfusion<sup style="font-size:70%">&reg;</sup>  supports only Razor view engine for ASP.NET MVC projects.
 * Compress Style Sheets – Option to compress style sheets.
 * Compress Scripts – Option to compress the scripts.
-* Name – Name your Syncfusion MVC Application.
+* Name – Name your Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Application.
 * Location – Choose the target location of your project.
-* Theme Selection – Choose the required theme. The Theme Preview section shows the controls preview before create the Syncfusion project.
+* Theme Selection – Choose the required theme. The Theme Preview section shows the controls preview before create the Syncfusion<sup style="font-size:70%">&reg;</sup>  project.
 
 ![Syncfusion Essential JS 1 ASP.NET MVC Sample Creator Project Configuration section](Sample-Creator_images/Sample-Creator-img6.jpeg)
 
-When you click the Create button, the new Syncfusion ASP.NET MVC project is created. The following is added in the project:
+When you click the Create button, the new Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC project is created. The following is added in the project:
 
 * Added the required Controller and View files in the project.
   
   ![Required Controller and View files added in the project for selected controls](Sample-Creator_images/Sample-Creator-img7.png)
 
-* Included the required Syncfusion ASP.NET MVC scripts and themes files.
+* Included the required Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC scripts and themes files.
   
-  ![Required Syncfusion ASP.NET MVC scripts and themes files added in the project](Sample-Creator_images/Sample-Creator-img8.png)
+  ![Required Syncfusion  ASP.NET MVC scripts and themes files added in the project](Sample-Creator_images/Sample-Creator-img8.png)
 
-* The required Syncfusion assemblies are added for selected controls under Project Reference.
+* The required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies are added for selected controls under Project Reference.
  
-  ![Required Syncfusion assemblies added in the project for the selected controls](Sample-Creator_images/Sample-Creator-img9.png)
+  ![Required Syncfusion  assemblies added in the project for the selected controls](Sample-Creator_images/Sample-Creator-img9.png)
 
-* Configure the Web.Config file by adding the Syncfusion reference assemblies.
+* Configure the Web.Config file by adding the Syncfusion<sup style="font-size:70%">&reg;</sup>  reference assemblies.
 
   ![Required Syncfusion assemblies configured in Web.config file for the selected controls](Sample-Creator_images/Sample-Creator-img10.jpeg)
 
 * Once the project is created you can open the project by clicking the Yes button. Refer the following screenshot for more information.
 
-  ![The project successfully created using Syncfusion Essential JS 1 ASP.NET MVC Sample Creator](Sample-Creator_images/Sample-Creator-img11.jpeg)
+  ![The project successfully created using Syncfusion  Essential JS 1 ASP.NET MVC Sample Creator](Sample-Creator_images/Sample-Creator-img11.jpeg)

--- a/Extension/ASPNET-MVC-Extension/Step-by-Step-Installation.md
+++ b/Extension/ASPNET-MVC-Extension/Step-by-Step-Installation.md
@@ -1,43 +1,43 @@
 ---
 layout: post
-title: Step by Step Installation | Extension | Syncfusion  
-description: Step by Step Installation procedure to install Syncfusion Web Sample Creator
+title: Step by Step Installation | Extension | Syncfusion   
+description: Step by Step Installation procedure to install Syncfusion  Web Sample Creator
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Step-by-Step Installation  
 
-The following procedure illustrates how to install Syncfusion Web Sample Creator. Before install the Syncfusion Web Sample Creator, make sure any of the following setups are installed. 
+The following procedure illustrates how to install Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator. Before install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator, make sure any of the following setups are installed. 
 
-   * Essential Studio for Enterprise Edition with all platforms
-   * Essential Studio for ASP.NET MVC
-   * Essential Studio for ASP.NET
-   * Essential Studio for ASP.NET Core
-   * Essential Studio for ASP.NET MVC(Classic)
+   * Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with all platforms
+   * Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC
+   * Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET
+   * Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET Core
+   * Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC(Classic)
 
-1. Double-click the Syncfusion Web Sample Creator Setup file. The Self-Extractor Wizard opens and extracts the package automatically.
+1. Double-click the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator Setup file. The Self-Extractor Wizard opens and extracts the package automatically.
 
    ![Syncfusion Web Sample Creator Setup Self-Extractor Wizard](Step-by-Step-Installation_images/Step-by-Step-Installation-img1.jpeg)
 
    N> The WinZip Self-Extractor extracts the syncfusionwebsamplecreator_(version).exe dialog, displaying the unzip operation of the package.
 
-   If complete Essential Studio suite or any of the required Essential Studio platform setups are installed, Syncfusion Web Sample Creator setup will be installed.
+   If complete Essential Studio<sup style="font-size:70%">&reg;</sup>  suite or any of the required Essential Studio<sup style="font-size:70%">&reg;</sup>  platform setups are installed, Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator setup will be installed.
    
    ![Syncfusion Web Sample Creator setup installation wizard](Step-by-Step-Installation_images/Step-by-Step-Installation-img2.jpeg)
 
-   If complete Essential Studio suite or any of the required Essential Studio platform setups are not installed, Syncfusion Web Sample Creator setup will show the below message.
+   If complete Essential Studio<sup style="font-size:70%">&reg;</sup>  suite or any of the required Essential Studio<sup style="font-size:70%">&reg;</sup>  platform setups are not installed, Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator setup will show the below message.
    
    ![Syncfusion Web Sample Creator setup validation message](Step-by-Step-Installation_images/Step-by-Step-Installation-img7.jpeg)
 
 2. After reading the terms, click the I accept the terms and conditions check box. 
 
-3. Click the Next button. The Installation location window opens. It shows the Syncfusion Essential Studio setup installed location.
+3. Click the Next button. The Installation location window opens. It shows the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  setup installed location.
 
    ![Syncfusion Web Sample Creator setup install location wizard](Step-by-Step-Installation_images/Step-by-Step-Installation-img4.jpeg)
 
-   N> It does not allow you to change the install path since its Add on setup for Syncfusion Essential Studio.
+   N> It does not allow you to change the install path since its Add on setup for Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio.
 
 4. To install it in the displayed default location, click the Install button.
 
@@ -47,8 +47,8 @@ The following procedure illustrates how to install Syncfusion Web Sample Creator
 
    ![Syncfusion Web Sample Creator setup installation completed wizard](Step-by-Step-Installation_images/Step-by-Step-Installation-img6.jpeg)
 
-5. Select the `Run Syncfusion Control Panel` check box to launch the `Syncfusion Control Panel` after installed.
+5. Select the `Run Syncfusion<sup style="font-size:70%">&reg;</sup>  Control Panel` check box to launch the `Syncfusion Control Panel` after installed.
 
-6. Click Finish button. Syncfusion Web Sample Creator is installed in your system and the [Syncfusion Control Panel](https://help.syncfusion.com/extension/aspnet-mvc-extension/sample-creator) is launched automatically.
+6. Click Finish button. Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Sample Creator is installed in your system and the [Syncfusion Control Panel](https://help.syncfusion.com/extension/aspnet-mvc-extension/sample-creator) is launched automatically.
 
 I>The syncfusionessentialextension.exe setup has renamed to syncfusionwebsamplecreator.exe from 2015 Volume 4 release.

--- a/Extension/ASPNET-MVC-Extension/Syncfusion-Project-Templates.md
+++ b/Extension/ASPNET-MVC-Extension/Syncfusion-Project-Templates.md
@@ -1,27 +1,27 @@
 ---
 layout: post
 title: Project Templates | ASP.NET MVC (Essential JS 1) | Syncfusion
-description: Syncfusion provides the Visual Studio Project Templates for the ASP.NET MVC platform to create a Syncfusion MVC application using Essential JS 1 components
+description: Syncfusion  provides the Visual Studio Project Templates for the ASP.NET MVC platform to create a Syncfusion  MVC application using Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Templates for ASP.NET MVC (Essential JS 1)
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates for ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup> JS 1)
 
-Syncfusion provides the Visual Studio Project Templates for the Syncfusion ASP.NET MVC, Syncfusion ASP.NET MVC (Classic) and ASP.NET MVC (Mobile) platforms to create a Syncfusion MVC application.
+Syncfusion provides the Visual Studio Project Templates for the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC, Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Classic) and ASP.NET MVC (Mobile) platforms to create a Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC application.
 
 Syncfusion ASP.NET MVC and ASP.NET MVC (Classic) Project Templates are included here,
 
-* Essential Studio for Enterprise Edition with the platforms ASP.NETMVC or ASP.NET MVC(Classic)
-* Essential Studio for ASP.NET MVC
-* Essential Studio for ASP.NET MVC (Classic)
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platforms ASP.NETMVC or ASP.NET MVC(Classic)
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC (Classic)
 
-I> This is not applicable from v.12.1.0.43 to v.13.1.0.30. Syncfusion ASP.NET MVC and ASP.NET MVC (Classic) Project Templates are excluded from MVC Extension setup and integrated into Essential Studio ASP.NET MVC and ASP.NET MVC (Classic) platforms.
+I> This is not applicable from v.12.1.0.43 to v.13.1.0.30. Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC and ASP.NET MVC (Classic) Project Templates are excluded from MVC Extension setup and integrated into Essential Studio<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC and ASP.NET MVC (Classic) platforms.
 
 ## ASP.NET MVC Extensions:
 
-By default, the Syncfusion ASP.NET MVC extensions are configured in Visual Studio. When you want the ASP.NET MVC (Classic) extension, you can install it from the installed location.
+By default, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC extensions are configured in Visual Studio. When you want the ASP.NET MVC (Classic) extension, you can install it from the installed location.
 
 Project Templates (ASP.NET MVC (Classic):
 
@@ -29,31 +29,31 @@ Location: `{Drive}\Program Files (x86)\Syncfusion\Essential Studio\<Version>\Ut
 
 For Example – VS2013:`C:\Program Files (x86)\Syncfusion\Essential Studio\13.2.0.18\Utilities\Extensions\ASP.NET MVC\Classic\4.5.1\Syncfusion.MVC.VSPackage.Web.Classic.vsix`
 
-Refer to the following steps to create the Syncfusion ASP.NET MVC and ASP.NET MVC (Classic) applications.
+Refer to the following steps to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC and ASP.NET MVC (Classic) applications.
 
-## Create Syncfusion MVC (Web) Project    
+## Create Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC (Web) Project    
 
-The following steps help you create the Syncfusion ASP.NET MVC (Essential JS 1) Application via the Visual Studio Project Template:
+The following steps help you create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) Application via the Visual Studio Project Template:
 
-> Before use the Syncfusion ASP.NET MVC (Essential JS 1) Project Template, check whether the **Syncfusion Essential JS1 AspNet MVC VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) Project Template, check whether the **Syncfusion<sup style="font-size:70%">&reg;</sup> Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet MVC VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
 
-1. To create a Syncfusion ASP.NET MVC (Essential JS 1) project, follow either one of the options below:
+1. To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) project, follow either one of the options below:
 
    **Option 1:**  
-    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC (EJ1) > Create New Syncfusion Project…** in **Visual Studio**.
+    Click **Syncfusion<sup style="font-size:70%">&reg;</sup> Menu** and choose **Essential Studio<sup style="font-size:70%">&reg;</sup> for ASP.NET MVC (EJ1) > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** in **Visual Studio**.
 
-    ![Choose Syncfusion ASP.NET MVC Web Application from Visual Studio new project dialog via Syncfusion menu](Create-Syncfusion-MVC-Project_images/Syncfusion_Menu_ProjectTemplate.png)
+    ![Choose Syncfusion  ASP.NET MVC Web Application from Visual Studio new project dialog via Syncfusion  menu](Create-Syncfusion-MVC-Project_images/Syncfusion_Menu_ProjectTemplate.png)
 
-    N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+    N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**  
-   Choose **File > New > Project** and navigate to **Syncfusion > Web > Syncfusion ASP.NET MVC (Essential JS 1) Application** in **Visual Studio**.
+   Choose **File > New > Project** and navigate to **Syncfusion > Web > Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 1) Application** in **Visual Studio**.
    
-   ![Choose Syncfusion ASP.NET MVC Web Application from Visual Studio new project dialog](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img1.png)
+   ![Choose Syncfusion  ASP.NET MVC Web Application from Visual Studio new project dialog](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img1.png)
 
 2. Name the Project, choose the destination location as required and set the Framework of the project then click OK. The Project Configuration Wizard appears.  
 
-3. Choose the options to configure the Syncfusion ASP.NET MVC Application by using the following Project Configuration window.
+3. Choose the options to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Application by using the following Project Configuration window.
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Web Project configuration wizard](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img2.jpeg)
 
@@ -79,11 +79,11 @@ The following steps help you create the Syncfusion ASP.NET MVC (Essential JS 1) 
 
    ![Choose the assembly location from where it is going to be added to the project](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img7.jpeg)
 
-   **Use CDN Support:** The master page of the project will be updated based on required Syncfusion CDN links.
+   **Use CDN Support:** The master page of the project will be updated based on required Syncfusion<sup style="font-size:70%">&reg;</sup>  CDN links.
 
    ![Choose CDN support](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img28.jpeg)
 
-4. When you have not chosen the Add Samples option then the Syncfusion ASP.NET MVC/ Syncfusion ASP.NET MVC (Classic) project is created with required assemblies, CSS and Script files only.
+4. When you have not chosen the Add Samples option then the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC/ Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Classic) project is created with required assemblies, CSS and Script files only.
 
 5. By choosing the Add Samples option you can add the code examples for your selected controls and its features.
 
@@ -97,11 +97,11 @@ The following steps help you create the Syncfusion ASP.NET MVC (Essential JS 1) 
 
    ![Choose required features](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img10.jpeg)
 
-6. Once the Project Configuration Wizard is done, the Syncfusion MVC Project is created.
+6. Once the Project Configuration Wizard is done, the Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Project is created.
 
    ![Required View and Controller files are added in the project for the selected controls](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img11.jpeg)
 
-7. Syncfusion references, Scripts, CSS and required Web.config entries are added to the Project.
+7. Syncfusion<sup style="font-size:70%">&reg;</sup>  references, Scripts, CSS and required Web.config entries are added to the Project.
 
    ![Required Syncfusion assemblies added in the project created for the selected controls](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img12.jpeg)
 
@@ -109,20 +109,20 @@ The following steps help you create the Syncfusion ASP.NET MVC (Essential JS 1) 
 
    ![Web.config file configured for the selected controls in the project created](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img14.jpeg)
 
-8. Then, Syncfusion licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+8. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
-   ![Syncfusion license registration required message box for Syncfusion Essential JS 1 ASP.NET MVC web projects](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img29.jpeg)
+   ![Syncfusion license registration required message box for Syncfusion  Essential JS 1 ASP.NET MVC web projects](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img29.jpeg)
 
-## Create Syncfusion MVC (Mobile) Project
+## Create Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC (Mobile) Project
 
-The following steps help you create the Syncfusion ASP.NET MVC (Mobile) Project via the Visual Studio Project Template.
+The following steps help you create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Mobile) Project via the Visual Studio Project Template.
 
-1. To create a Syncfusion Project, choose **New Project -> Syncfusion -> Mobile -> Syncfusion ASP.NET MVC(Mobile) Application** from Visual Studio.
+1. To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  Project, choose **New Project -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Mobile -> Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC(Mobile) Application** from Visual Studio.
 
-   ![Choose Syncfusion ASP.NET MVC Mobile Application from Visual Studio new project dialog](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img15.jpeg)
+   ![Choose Syncfusion  ASP.NET MVC Mobile Application from Visual Studio new project dialog](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img15.jpeg)
 
 2. Name the Project, choose the destination location as required and set the Framework of the project then click OK. The Project Configuration Wizard appears.  
-3. Choose the options to configure the Syncfusion ASP.NET MVC Application by using the following Project Configuration window.
+3. Choose the options to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Application by using the following Project Configuration window.
 
    ![Syncfusion Essential JS 1 ASP.NET MVC Mobile project configuration wizard](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img16.jpeg)
 
@@ -152,11 +152,11 @@ The following steps help you create the Syncfusion ASP.NET MVC (Mobile) Project 
 
    ![Choose the required controls](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img22.jpeg)
 
-4. Once the Project Configuration Wizard is done, the Syncfusion MVC Project is created.
+4. Once the Project Configuration Wizard is done, the Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Project is created.
 
    ![Required view and controller files added in the Syncfusion Essential JS 1 ASP.NET MVC Mobile project created](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img23.jpeg)
 
-5. Syncfusion references, Scripts, CSS and required Web.config entries are added to the Project.
+5. Syncfusion<sup style="font-size:70%">&reg;</sup>  references, Scripts, CSS and required Web.config entries are added to the Project.
 
    ![Required assemblies added as a reference in the project created](Create-Syncfusion-MVC-Project_images/CreateSyncfusionMVCProject-img24.jpeg)
 

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio-Code/create-project.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio-Code/create-project.md
@@ -1,33 +1,33 @@
 ---
 layout: post
 title: Project Templates | ASP.NET Core (Essential JS 2) | Syncfusion
-description: Syncfusion provides Project Templates for ASP.NET Core to create the Syncfusion ASP.NET Core Application using EJ2 Core components from Visual Studio Code.
+description: Syncfusion  provides Project Templates for ASP.NET Core to create the Syncfusion  ASP.NET Core Application using EJ2 Core components from Visual Studio Code.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Creating a Syncfusion ASP.NET Core Application
+# Creating a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application
 
-Syncfusion provides **Visual Studio Code project templates** for creating Syncfusion ASP.NET Core application. Syncfusion ASP.NET Core generates application that include the necessary Syncfusion NuGet packages, namespaces, and component render code for the Calendar, Button, and DataGrid components, as well as the style for making Syncfusion component development easier.
+Syncfusion provides **Visual Studio Code project templates** for creating Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application. Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core generates application that include the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, namespaces, and component render code for the Calendar, Button, and DataGrid components, as well as the style for making Syncfusion<sup style="font-size:70%">&reg;</sup>  component development easier.
 
-> The Syncfusion Visual Studio Code project template provides support for ASP.NET Core project templates from v20.1.0.47.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Code project template provides support for ASP.NET Core project templates from v20.1.0.47.
 
 The following instructions assist you in creating **Syncfusion ASP.NET Core Applications** using **Visual Studio Code**:
 
-1. To create a Syncfusion ASP.NET Core application in Visual Studio Code, open the command palette by pressing **Ctrl+Shift+P**. Search for the word **Syncfusion** in the Visual Studio Code palette to get the templates provided by Syncfusion.
+1. To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application in Visual Studio Code, open the command palette by pressing **Ctrl+Shift+P**. Search for the word **Syncfusion** in the Visual Studio Code palette to get the templates provided by Syncfusion.
 
      ![command-palette](images/command-palette.png)
 
-2. Select **Syncfusion ASP.NET Core Template Studio: Launch**, then press **Enter** key. The template studio wizard for configuring the Syncfusion ASP.NET Core application is launched. Then, provide the Project Name and Project Path.
+2. Select **Syncfusion ASP.NET Core Template Studio: Launch**, then press **Enter** key. The template studio wizard for configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application is launched. Then, provide the Project Name and Project Path.
  
      ![core-wizard](images/launch-window.png)
 
-3. Select either **Next** or the **Project Type** tab. Syncfusion ASP.NET Core Project Types will be displayed. Select one of the following Syncfusion ASP.NET Core project types:
+3. Select either **Next** or the **Project Type** tab. Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Project Types will be displayed. Select one of the following Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core project types:
 
-    * Syncfusion Web Application (Model-View-Controller)
-    * Syncfusion Angular
-    * Syncfusion React.js
+    * Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Application (Model-View-Controller)
+    * Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular
+    * Syncfusion<sup style="font-size:70%">&reg;</sup>  React.js
 
     ![project-type](images/project-type.png)
 
@@ -35,12 +35,12 @@ The following instructions assist you in creating **Syncfusion ASP.NET Core Appl
 
     ![project-configuration](images/project-configuration.png)
 
-    > In assets from the Installed location option will be available when the Syncfusion Essential JavaScript 2 build has been installed.
+    > In assets from the Installed location option will be available when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 build has been installed.
 
-5. Click the **Create** button. The Syncfusion ASP.NET Core application will be created. The created Syncfusion ASP.NET Core application has the Syncfusion NuGet packages, NPM Packages, styles, and the component render code for the Syncfusion component added to the index page.T
+5. Click the **Create** button. The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application will be created. The created Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application has the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, NPM Packages, styles, and the component render code for the Syncfusion<sup style="font-size:70%">&reg;</sup>  component added to the index page.T
 
-6. You can run the application to see the Syncfusion components. Click **F5** or go to **Run>Start Debugging**.
+6. You can run the application to see the Syncfusion<sup style="font-size:70%">&reg;</sup>  components. Click **F5** or go to **Run>Start Debugging**.
 
     ![debugging](images/debugging.png)
 
-7. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio. 
+7. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>. 

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio-Code/download-and-installation.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio-Code/download-and-installation.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: Download and Installation | ASP.NET Core (Essential JS2) | Syncfusion
-description: How to download and install the Syncfusion ASP.NET Core (Essential JS2) Visual Studio Code Extensions from Visual Studio Code Market Place
+description: How to download and install the Syncfusion  ASP.NET Core (Essential JS2) Visual Studio Code Extensions from Visual Studio Code Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -13,7 +13,7 @@ Syncfusion publishes the Visual Studio Code extension in Visual Studio Code mark
 
 ## Prerequisites
 
-To install the Syncfusion ASP.NET Core Visual Studio Code extension and the creation of Syncfusion ASP.NET Core apps using any of the project types (Syncfusion Web Application (Model-View-Controller), Syncfusion Angular, and Syncfusion React), the following required software must be installed:
+To install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Visual Studio Code extension and the creation of Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core apps using any of the project types (Syncfusion Web Application (Model-View-Controller), Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular, and Syncfusion<sup style="font-size:70%">&reg;</sup>  React), the following required software must be installed:
 
 * [Visual Studio Code 1.29.0 or later](https://code.visualstudio.com/download)
 * [Visual Studio 2019 16.3 Preview 2](https://visualstudio.microsoft.com/vs/) or later
@@ -24,7 +24,7 @@ To install the Syncfusion ASP.NET Core Visual Studio Code extension and the crea
 
 ## Install through the Visual Studio Code extensions
 
-The following steps explain how to install the Syncfusion ASP.NET Core Visual Studio Code extensions from Visual Studio Code:
+The following steps explain how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Visual Studio Code extensions from Visual Studio Code:
 
 1. Open Visual Studio Code.
 
@@ -40,17 +40,17 @@ The following steps explain how to install the Syncfusion ASP.NET Core Visual St
 
     ![reload-window](images/reload-window.png)
 
-6. Now, you can create a new Syncfusion ASP.NET Core application by using the Syncfusion ASP.NET Core extensions from the Visual Studio Code Palette. Find the Syncfusion ASP.NET Core Template Studio: Launch from Visual Studio Code commands to open the Syncfusion ASP.NET Core Template Studio wizard.
+6. Now, you can create a new Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application by using the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core extensions from the Visual Studio Code Palette. Find the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Template Studio: Launch from Visual Studio Code commands to open the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Template Studio wizard.
 
    ![command-palette](images/command-palette.png)
 
 ## Install from the Visual Studio Code Marketplace
 
-The following steps explain how to install Syncfusion ASP.NET Core applications from the Visual Studio Code Marketplace:
+The following steps explain how to install Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core applications from the Visual Studio Code Marketplace:
 
-1. Open the Syncfusion ASP.NET Core Visual Studio Code Extension in Visual Studio Code Marketplace.
+1. Open the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Visual Studio Code Extension in Visual Studio Code Marketplace.
 
-2. Click Install from Visual Studio Code Marketplace to open the popup with the information, “**Open Visual Studio Code.**” Then, click Open Visual Studio Code, and Syncfusion ASP.NET Core Extension will open in Visual Studio Code.
+2. Click Install from Visual Studio Code Marketplace to open the popup with the information, “**Open Visual Studio Code.**” Then, click Open Visual Studio Code, and Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Extension will open in Visual Studio Code.
 
 3. Click the Install button in the “**ASP.NET Core VS Code Extensions - Syncfusion**” extension.
 
@@ -58,6 +58,6 @@ The following steps explain how to install Syncfusion ASP.NET Core applications 
 
      ![reload-window](images/reload-window.png)
 
-5. Now, you can create a new Syncfusion ASP.NET Core application by using the Syncfusion ASP.NET Core extensions from the Visual Studio Code Palette. Find the **Syncfusion ASP.NET Core Template Studio: Launch** from Visual Studio Code commands to open the Syncfusion ASP.NET Core Template Studio wizard.
+5. Now, you can create a new Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application by using the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core extensions from the Visual Studio Code Palette. Find the **Syncfusion ASP.NET Core Template Studio: Launch** from Visual Studio Code commands to open the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Template Studio wizard.
 
      ![command-palette](images/command-palette.png)

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio-Code/overview.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio-Code/overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ASP.NET Core (Essential JS 2) Extension | Extension | Syncfusion
-description: The Syncfusion ASP.NET Core Extensions provide quick access to create or configure the Syncfusion ASP.NET projects along with Essential JS 2 components.
+description: The Syncfusion ASP.NET Core Extensions provide quick access to create or configure the Syncfusion  ASP.NET projects along with Essential JS 2 components.
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
@@ -9,8 +9,8 @@ documentation: ug
 
 # Overview of ASP.NET Core Extension for Visual Studio Code
 
-The Syncfusion ASP.NET Core Extension for Visual Studio Code makes it simple to use the Syncfusion ASP.NET Core components in the ASP.NET Core application by simply configuring the Syncfusion NPM or NuGet packages and themes.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Extension for Visual Studio Code makes it simple to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core components in the ASP.NET Core application by simply configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  NPM or NuGet packages and themes.
 
-The Syncfusion ASP.NET Core Extension provides the following support in Visual Studio Code:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Extension provides the following support in Visual Studio Code:
 
-[Create-Project](create-project): Creates Syncfusion ASP.NET Core application (Syncfusion Web Application (Model-View-Controller), Syncfusion Angular, Syncfusion React.js) with the necessary configuration to use in Syncfusion ASP.NET Core component during development.
+[Create-Project](create-project): Creates Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application (Syncfusion Web Application (Model-View-Controller), Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular, Syncfusion<sup style="font-size:70%">&reg;</sup>  React.js) with the necessary configuration to use in Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core component during development.

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Overview.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Overview.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: ASP.NET Core (Essential JS 2) Extension | Extension | Syncfusion
-description: The Syncfusion ASP.NET Core Extensions provide quick access to create or configure the Syncfusion ASP.NET projects along with Essential JS 2 components.
+description: The Syncfusion  ASP.NET Core Extensions provide quick access to create or configure the Syncfusion ASP.NET projects along with Essential JS 2 components.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -11,20 +11,20 @@ documentation: ug
 
 ## Overview
 
-The Syncfusion ASP.NET Core (Essential JS 2) Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Visual Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.
 
-> Syncfusion Extension is published in Visual Studio Marketplace. You can download ASP.NET Core (EJ2) Extensions [here](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.ASPNETCoreExtensions)
+> Syncfusion<sup style="font-size:70%">&reg;</sup>  Extension is published in Visual Studio Marketplace. You can download ASP.NET Core (EJ2) Extensions [here](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.ASPNETCoreExtensions)
 
 ## IMPORTANT
 
-The Syncfusion ASP.NET Core (Essential JS 2) menu option is available from v17.1.0.32.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) menu option is available from v17.1.0.32.
 
-The Syncfusion provides the following supports in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the following supports in Visual Studio:
 
-1. [Project-Template](syncfusion-project-templates):  Creates the Syncfusion ASP.NET Core (Essential JS 2) application by adding the required Essential JS 2 components.
-2. [Convert project](project-conversion): Converts an existing ASP.NET Core application into a Syncfusion ASP.NET Core (Essential JS 2) application by adding the required Syncfusion assemblies and resource files.
-3. [Upgrade project](project-migration): Upgrades the existing Syncfusion ASP.NET Core (Essential JS 2) application from one Essential Studio version to another version.
-4. [Creator sample](sample-creator): Creates the Syncfusion ASP.NET Core (Essential JS2) application with the sample code of required controls and features.
+1. [Project-Template](syncfusion-project-templates):  Creates the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) application by adding the required Essential JS 2 components.
+2. [Convert project](project-conversion): Converts an existing ASP.NET Core application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and resource files.
+3. [Upgrade project](project-migration): Upgrades the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.
+4. [Creator sample](sample-creator): Creates the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS2) application with the sample code of required controls and features.
 
 ### No project selected in Visual Studio
 
@@ -34,8 +34,8 @@ The Syncfusion provides the following supports in Visual Studio:
 
 ![selected microsoft](images/selected-project.png)
 
-### Selected Syncfusion ASP.NET Core (Essential JS2) application in Visual Studio
+### Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS2) application in Visual Studio
 
 ![selected syncfusion](images/selected-syncfusion-project.png)
 
-> From Visual Studio 2019, Syncfusion menu is available under Extension in Visual Studio menu.
+> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extension in Visual Studio menu.

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Project-Conversion.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Project-Conversion.md
@@ -1,55 +1,55 @@
 ---
 layout: post
 title: Project Conversion | ASP.NET Core (Essential JS 2) | Syncfusion
-description: Project Conversion is a add-in that converts ASP.NET Core application into a Syncfusion ASP.NET Core application by adding required Essential JS 2 components
+description: Project Conversion is a add-in that converts ASP.NET Core application into a Syncfusion  ASP.NET Core application by adding required Essential JS 2 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Conversion
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion
 
-Syncfusion ASP.NET Core conversion is a Visual Studio add-in that converts an existing ASP.NET Core application into a Syncfusion ASP.NET Core (Essential JS 2) Web application by adding the required assemblies and resource files.
+Syncfusion ASP.NET Core conversion is a Visual Studio add-in that converts an existing ASP.NET Core application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Web application by adding the required assemblies and resource files.
 
-> The Syncfusion ASP.NET Core (Essential JS 2) Web Application Project conversion utility is available from v16.3.0.17. Before use, the Syncfusion ASP.NET Core Project Conversion, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Conversion will not be shown.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential<sup style="font-size:70%">&reg;</sup> JS 2) Web Application Project conversion utility is available from v16.3.0.17. Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Project Conversion, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Conversion will not be shown.
 
-The steps below help you to convert the ASP.NET Core application to the Syncfusion ASP.NET Core application via the Visual Studio 2019:
+The steps below help you to convert the ASP.NET Core application to the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application via the Visual Studio 2019:
 
 1. Open an existing Microsoft ASP.NET Core Web Application or create a new Microsoft ASP.NET Core Web Application.
 
-2. To open the Syncfusion Project Conversion Wizard, follow either one of the options below:
+2. To open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion Wizard, follow either one of the options below:
 
     **Option 1:**
 
-    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core > Convert to Syncfusion ASP.NET Core Application…** in **Visual Studio Menu**.
+    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core > Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application…** in **Visual Studio Menu**.
 
     ![convert project](images/convert-new-app.png)
 
-    > From Visual Studio 2019, Syncfusion menu is available under **Extensions** in Visual Studio menu.
+    > From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under **Extensions** in Visual Studio menu.
 
     ![convert project](images/convert-new-app-2019.png)
 
     **Option 2:**
 
-    Right-click the **Project** from Solution Explorer, select **Syncfusion Web**, and choose the **Convert to Syncfusion ASP.NET Core Application…**
+    Right-click the **Project** from Solution Explorer, select **Syncfusion Web**, and choose the **Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application…**
 
     ![convert to syncfusion](images/convert-to-syncfusion-ASpnet-core.png)
 
-3. The Syncfusion ASP.NET Core Project Conversion window will appear. You can choose the required version of Syncfusion ASP.NET Core, Assets from, and Themes to convert the application.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Project Conversion window will appear. You can choose the required version of Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core, Assets from, and Themes to convert the application.
 
     ![project conversion wizard](images/project-conversion-wizard.png)
 
     The following configurations are used in the Project conversion wizard.
 
-    **Assets From:** Load the Syncfusion Essential JS 2 assets to ASP.NET Core Project, from either NPM, CDN, or Installed Location.
+    **Assets From:** Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET Core Project, from either NPM, CDN, or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
     **Choose the Theme:** Choose the required theme.
 
 4. Check the **“Enable a backup before converting”** checkbox if you want to take the project backup and choose the location.
 
-5. The required Syncfusion NuGet packages, Scripts and CSS are included in the ASP.NET Core Web application. Refer to the following screenshots for more information.
+5. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, Scripts and CSS are included in the ASP.NET Core Web application. Refer to the following screenshots for more information.
 
     ![dependencies](images/dependencies.png)
 
@@ -61,4 +61,4 @@ The steps below help you to convert the ASP.NET Core application to the Syncfusi
 
     ![BackupLocation](images/BackupLocation.png)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Project-Migration.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Project-Migration.md
@@ -1,25 +1,25 @@
 ---
 layout: post
 title: Project Migration | ASP.NET Core (Essential JS 2) | Syncfusion
-description: Project Migration is a add-in that allows you to migrate the existing Syncfusion ASP.NET Core Application from one Essential Studio version to another version
+description: Project Migration is a add-in that allows you to migrate the existing Syncfusion ASP.NET Core Application from one Essential Studio  version to another version
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Upgrading Syncfusion ASP.NET Core application to latest version
+# Upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application to latest version
 
-The Syncfusion ASP.NET Core migration add-in for Visual Studio allows you to migrate an existing Syncfusion ASP.NET Core application from one version of Essential Studio version to another version. This reduces the amount of manual work required when migrating the Syncfusion version.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core migration add-in for Visual Studio allows you to migrate an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application from one version of Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version. This reduces the amount of manual work required when migrating the Syncfusion<sup style="font-size:70%">&reg;</sup>  version.
 
 ## IMPORTANT
 
-The Syncfusion ASP.NET Core (Essential JS 2) Web Application Project Migration utility is available from v16.3.0.17.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Web Application Project Migration utility is available from v16.3.0.17.
 
-> Before use, the Syncfusion ASP.NET Core Project Migration, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Migration will not be shown.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Project Migration, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Migration will not be shown.
 
-The steps below will assist you to upgrade the Syncfusion version in the Syncfusion ASP.NET Core application via Visual Studio 2019:
+The steps below will assist you to upgrade the Syncfusion<sup style="font-size:70%">&reg;</sup>  version in the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application via Visual Studio 2019:
 
-1. Open the Syncfusion ASP.NET Core application that uses the Syncfusion component.
+1. Open the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application that uses the Syncfusion<sup style="font-size:70%">&reg;</sup>  component.
 
 2. To open the Migration Wizard, either one of the following options should be followed:
 
@@ -29,30 +29,30 @@ The steps below will assist you to upgrade the Syncfusion version in the Syncfus
 
     ![migrate project](images/migrate-project.png)
 
-    > From Visual Studio 2019, Syncfusion menu is available under **Extensions** in Visual Studio menu.
+    > From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under **Extensions** in Visual Studio menu.
 
     **Option 2**
 
-    Right-click the **Syncfusion ASP.NET Core Application** from Solution Explorer and select **Syncfusion Web**. Choose **Migrate the Syncfusion ASP.NET Core Project to Another Version…**
+    Right-click the **Syncfusion ASP.NET Core Application** from Solution Explorer and select **Syncfusion Web**. Choose **Migrate the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Project to Another Version…**
 
     ![migrate syncfuion project](images/migrate-syncfusion-EJ2.png)
 
-3. The Syncfusion Project Migration window will appear. You can choose the required version of Syncfusion ASP.NET Core to migrate.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Migration window will appear. You can choose the required version of Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core to migrate.
 
     ![project migration](images/project-migration.png)
 
-    > The versions are loaded from the Syncfusion ASP.NET Core NuGet packages which published in [NuGet.org](https://www.nuget.org/packages?q=Tags%3A%22aspnetcore%22syncfusion) and it requires internet connectivity.
+    > The versions are loaded from the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core NuGet packages which published in [NuGet.org](https://www.nuget.org/packages?q=Tags%3A%22aspnetcore%22syncfusion) and it requires internet connectivity.
 
-    **Assets From:** Load the Syncfusion Essential JS 2 assets to ASP.NET Core Project, from either NPM, CDN or Installed Location.
+    **Assets From:** Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET Core Project, from either NPM, CDN or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
 4. Check the **“Enable a backup before migrating”** checkbox if you want to take the project backup and choose location.
 
-5. The Syncfusion Reference Assemblies, Scripts, and CSS are updated to the corresponding version in the project.
+5. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Assemblies, Scripts, and CSS are updated to the corresponding version in the project.
 
     If you enabled project backup before migrating, the old project was saved in the specified backup path location, as shown below once the migration process completed
 
     ![BackupLocation](images/BackupLocation.png)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Sample-Creator.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Sample-Creator.md
@@ -1,19 +1,19 @@
 ---
 layout: post
 title: Sample Creator | ASP.NET Core (Essential JS 2) | Syncfusion
-description: Sample Creator is a utility that allows you to create the Syncfusion ASP.NET Core (Essential JS 2) Projects with required Syncfusion controls
+description: Sample Creator is a utility that allows you to create the Syncfusion  ASP.NET Core (Essential JS 2) Projects with required Syncfusion controls
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Creating Syncfusion ASP.NET Core application
+# Creating Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core application
 
-The Syncfusion Sample Creator is a tool that lets you make Syncfusion ASP.NET Core (Essential JS 2) projects with sample code for required Syncfusion component features and Syncfusion control configuration.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Sample Creator is a tool that lets you make Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) projects with sample code for required Syncfusion<sup style="font-size:70%">&reg;</sup>  component features and Syncfusion<sup style="font-size:70%">&reg;</sup>  control configuration.
 
-> The Syncfusion ASP.NET Core (Essential JS 2) Sample Creator utility is available from v16.3.0.17.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Sample Creator utility is available from v16.3.0.17.
 
-The following steps is used to create the Syncfusion ASP.NET Core (Essential JS 2) Application by using the Sample Creator utility:
+The following steps is used to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Application by using the Sample Creator utility:
 
 1. Follow one of the options below to launch the ASP.NET Core (Essential JS 2) Sample Creator application:
 
@@ -25,15 +25,15 @@ The following steps is used to create the Syncfusion ASP.NET Core (Essential JS 
 
     **Option 2:**
 
-    Launch the Syncfusion ASP.NET Core (Essential JS 2) Control Panel and click the Sample Creator button to launch the ASP.NET Core (Essential JS 2) Sample Creator utility. For further information, see the screenshot below.
+    Launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Control Panel and click the Sample Creator button to launch the ASP.NET Core (Essential JS 2) Sample Creator utility. For further information, see the screenshot below.
 
     ![control-panel](images/sample-creator-control-panel.png)
 
-2. Syncfusion controls and features are listed in the ASP.NET Core (Essential JS 2) Sample Creator.
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  controls and features are listed in the ASP.NET Core (Essential JS 2) Sample Creator.
 
     ![controls-list](images/controls-list.png)
 
-    **Controls Selection:** Choose the required controls. The controls are grouped with Syncfusion products.
+    **Controls Selection:** Choose the required controls. The controls are grouped with Syncfusion<sup style="font-size:70%">&reg;</sup>  products.
 
     ![control selection](images/controls-selection.png)
 
@@ -59,15 +59,15 @@ The following steps is used to create the Syncfusion ASP.NET Core (Essential JS 
 
     > .NET 8.0 is available from v23.2.4 and support from Visual Studio 2022.
 
-    **Assets From**: Choose the Syncfusion Essential JS 2 assets to ASP.NET Core Project, either NPM, CDN, or Installed Location.
+    **Assets From**: Choose the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET Core Project, either NPM, CDN, or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
-    **Name**: Name your Syncfusion ASP.NET Core (Essential JS 2) Application.
+    **Name**: Name your Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Application.
 
     **Location**: Choose the target location of your project.
 
-    **Theme Selection**: Choose the required theme. This section shows the controls preview before creating the Syncfusion project.
+    **Theme Selection**: Choose the required theme. This section shows the controls preview before creating the Syncfusion<sup style="font-size:70%">&reg;</sup>  project.
 
     ![theme selection](images/theme-selection.png)
 
@@ -75,16 +75,16 @@ The following steps is used to create the Syncfusion ASP.NET Core (Essential JS 
 
     ![create](images/create-button.png)
 
-3. The new Syncfusion ASP.NET Core (Essential JS 2) project is created with the resources.
+3. The new Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) project is created with the resources.
 
     * Added the required Controllers and View files in the project.
 
     ![controllers](images/required-controllers.png)
 
-    * Included the required Syncfusion ASP.NET Core (Essential JS 2) scripts and theme files.
+    * Included the required Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) scripts and theme files.
 
     ![scripts and css](images/scripts-css.png)
 
-    * Restored the required Syncfusion NuGet packages for selected controls under dependencies.
+    * Restored the required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages for selected controls under dependencies.
 
     ![nuget packages](images/nuget-packges.png)

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Scaffolding.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Scaffolding.md
@@ -1,27 +1,27 @@
 ---
 layout: post
 title: Scaffolding | ASP.NET Core | Syncfusion
-description: Code-generation Framework for Syncfusion ASP.NET Core platform to quickly create the Controller and Views in a short time.
+description: Code-generation Framework for Syncfusion  ASP.NET Core platform to quickly create the Controller and Views in a short time.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # ASP.NET Core Scaffolding
 
-Syncfusion provides **Visual Studio Scaffolding** for Syncfusion ASP.NET Core platform to quickly add code that interacts with data models and reduce the amount of time to develop with data operation in your project. Scaffolding provides an easier way to create Views and Controller action methods for Syncfusion ASP.NET Core DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, Document Editor, and PDF Viewer controls.
+Syncfusion provides **Visual Studio Scaffolding** for Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core platform to quickly add code that interacts with data models and reduce the amount of time to develop with data operation in your project. Scaffolding provides an easier way to create Views and Controller action methods for Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, Document Editor, and PDF Viewer controls.
 
 > Check that at least one Entity Framework model exists, and the application has been compiled once. If no Entity Framework model exist in your application, refer to this [documentation](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-3.1) to generate the Entity Framework model. After the model file has been added, check that the required DBContext and properties have been added. Build the application before try scaffolding. If any changes have been done in the model properties, rebuild the application once before performing scaffolding.
 
 <!-- markdownlint-disable MD026 -->
 
-> The Syncfusion ASP.NET Core UI Scaffolder is available from 18.4.0.39 to ASP.NET Core web application.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core UI Scaffolder is available from 18.4.0.39 to ASP.NET Core web application.
 
 ## Add a scaffolded item
 
 The following steps explain you how to add a scaffolded item to your ASP.NET Core Web application.
 
-> Before use, the Syncfusion ASP.NET Core Scaffolding, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/VS2019-Extensions/download-and-installation/) help topic.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Scaffolding, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/VS2019-Extensions/download-and-installation/) help topic.
 
  1. Right-click the **Controllers** folder in the Solution Explorer, click **Add**, and then select **New Scaffolded Item…**
 
@@ -29,31 +29,31 @@ The following steps explain you how to add a scaffolded item to your ASP.NET Cor
 
  2. In the **Add Scaffold dialog**, select **Syncfusion ASP.NET Core UI Scaffolder**, and then click **‘Add’**.
 
-    ![Choose Syncfusion Scaffolding from Visual Studio Add scaffold dialog](images/Scaffolding_Add_Item2.png)
+    ![Choose Syncfusion<sup style="font-size:70%">&reg;</sup>  Scaffolding from Visual Studio Add scaffold dialog](images/Scaffolding_Add_Item2.png)
 
- 3. In the Syncfusion UI Scaffolder dialog, select the desired Syncfusion control to perform scaffolding, and then click **Next**.
+ 3. In the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder dialog, select the desired Syncfusion<sup style="font-size:70%">&reg;</sup>  control to perform scaffolding, and then click **Next**.
 
     ![Choose required control](images/Scaffolding_Add_Item3.png)
 
- 4. Selected control model dialog will be launched in the Syncfusion UI Scaffolder. Enter the **Controller Name** and **View Name** as application requirements, and then select the required **Model Class** of the active project and its relevant **Data Context Class**, and then click **Next**.
+ 4. Selected control model dialog will be launched in the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder. Enter the **Controller Name** and **View Name** as application requirements, and then select the required **Model Class** of the active project and its relevant **Data Context Class**, and then click **Next**.
 
     ![Choose required Model](images/Scaffolding_Add_Item4.png)
 
- 5. Selected control feature dialog will be launched in the Syncfusion UI Scaffolder. Choose the required features, update the required data field, and then click **Add**.
+ 5. Selected control feature dialog will be launched in the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder. Choose the required features, update the required data field, and then click **Add**.
 
     ![Choose required selected control features](images/Scaffolding_Add_Item5.png)
 
- 6. The **Controller** and the corresponding **View** files will be added into the application with the selected features of Syncfusion control code snippet.
+ 6. The **Controller** and the corresponding **View** files will be added into the application with the selected features of Syncfusion<sup style="font-size:70%">&reg;</sup>  control code snippet.
 
     ![Required Controller and View files added in the project for the selected control](images/Scaffolding_Add_Item6.png)
 
  7. Then, add navigation to the created view file based on your requirement to open in the webpage.
 
- 8. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+ 8. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-## Syncfusion ASP.NET Core Command-line Scaffolding
+## Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Command-line Scaffolding
 
-Syncfusion provides **Scaffolding command-line** for Syncfusion ASP.NET Core to quickly add code that interacts with data models and reduce the amount of time to develop with data operation in your project. Scaffolding provides an easier way to create view file and Controller action methods for Syncfusion ASP.NET Core DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, Document Editor, and PDF Viewer controls.
+Syncfusion provides **Scaffolding command-line** for Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core to quickly add code that interacts with data models and reduce the amount of time to develop with data operation in your project. Scaffolding provides an easier way to create view file and Controller action methods for Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, Document Editor, and PDF Viewer controls.
 
 N>Check that at least one Entity Framework model exists. If no Entity Framework model exist in your application, refer to this [documentation](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-3.1) to generate the Entity Framework model. After the model file has been added, check that the required DBContext and properties are added. Now, build the application, and try scaffolding. If any changes made in the model properties, rebuild the application once before perform scaffolding.
 
@@ -113,15 +113,15 @@ The following steps explains how to add a scaffolded item from command-line to y
 
     ![CommandLine Scaffold](images/commandline.png)
 
-5. As we can see controller and view files generated successfully and also added the Syncfusion NuGet packages and styles which is required to render Syncfusion control.
+5. As we can see controller and view files generated successfully and also added the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages and styles which is required to render Syncfusion<sup style="font-size:70%">&reg;</sup>  control.
 
     ![ASPNETCore added Files](images/Corefiles.png)
     ![ASPNETCore Service Changes](images/CoreScript.png)
 
 <!-- markdownlint-disable MD026 -->
 
-## How to render Syncfusion control?
+## How to render Syncfusion<sup style="font-size:70%">&reg;</sup>  control?
 
-Refer to the following UG links to render Syncfusion control after performed scaffolding.
+Refer to the following UG links to render Syncfusion<sup style="font-size:70%">&reg;</sup>  control after performed scaffolding.
 
 [Configure using Syncfusion.EJ2.AspNet.Core package](https://ej2.syncfusion.com/aspnetcore/documentation/getting-started/visual-studio-2017/)

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Syncfusion-Notifications.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications | ASP.NET Core | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in ASP.NET Core applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in ASP.NET Core applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio<sup style="font-size:70%">&reg;</sup>. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> ASP.NET Core**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> ASP.NET Core**
 
 ![Option Page](images/core-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your ASP.NET Core application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your ASP.NET Core application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/core-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/core-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio ASP.NET Core - EJ2,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your ASP.NET Core development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio ASP.NET Core - EJ2,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your ASP.NET Core development projects.
 
 ![Build Notification](images/core-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your ASP.NET Core application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your ASP.NET Core application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/core-invalid.png)
 

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Syncfusion-Project-Templates.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/Syncfusion-Project-Templates.md
@@ -1,43 +1,43 @@
 ---
 layout: post
 title: Project Templates | ASP.NET Core (Essential JS 2) | Syncfusion
-description: Syncfusion provides Visual Studio Project Templates for ASP.NET Core platform to create the Syncfusion ASP.NET Core Application using Essential JS 2 components
+description: Syncfusion  provides Visual Studio Project Templates for ASP.NET Core platform to create the Syncfusion  ASP.NET Core Application using Essential JS 2 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Templates of ASP.NET Core (Essential JS 2)
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates of ASP.NET Core (Essential JS 2)
 
-Syncfusion provides the **Visual Studio Project Templates** for the Syncfusion ASP.NET Core platform to create the Syncfusion ASP.NET Core Web Application using Essential JS 2 components.
+Syncfusion provides the **Visual Studio Project Templates** for the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core platform to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application using Essential<sup style="font-size:70%">&reg;</sup> JS 2 components.
 
-> The Syncfusion ASP.NET Core (Essential JS 2) project templates are available from v16.2.0.41.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) project templates are available from v16.2.0.41.
 
 The following steps is used to create the **Syncfusion ASP.NET Core (Essential JS 2) Web Application** through the **Visual Studio Project Template**.
 
-> Before use the Syncfusion ASP.NET Core Project Template, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/download-and-installation) help topic.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Project Template, check whether the **ASP.NET Core Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetcore/documentation/visual-studio-integration/download-and-installation) help topic.
 
-1. To create the Syncfusion ASP.NET Core (Essential JS 2) project, follow either one of the options below:
+1. To create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) project, follow either one of the options below:
 
     **Option 1**
 
-    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ2) > Create New Syncfusion Project…** in **Visual Studio**.
+    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ2) > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** in **Visual Studio**.
 
     ![new project](images/new-project.png)
 
-    > From Visual Studio 2019, Syncfusion menu is available under Extension in Visual Studio menu.
+    > From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extension in Visual Studio menu.
 
     ![new project](images/SyncfusionMenu.png)
 
     **Option 2**
 
-    Choose **File > New > Project** and navigate to **Syncfusion > .NET Core > Syncfusion ASP.NET Core (Essential JS 2) Web Application** in **Visual Studio**.
+    Choose **File > New > Project** and navigate to **Syncfusion > .NET Core > Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Web Application** in **Visual Studio**.
 
     ![syncfusion template](images/syncfusion-template.png)
 
 2. Name the **Project**, choose the destination location, and then click **OK**. The Project Configuration Wizard appears.
 
-3. Choose the options to configure the Syncfusion ASP.NET Core (Essential JS 2) Application in the following Project Configuration dialog.
+3. Choose the options to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Application in the following Project Configuration dialog.
 
     ![project configuration](images/project-configuration.png)
 
@@ -56,15 +56,15 @@ The following steps is used to create the **Syncfusion ASP.NET Core (Essential J
     | Angular | .NET 5.0, .NET 6.0, and .NET 7.0 | Material, Fabric, Fluent, Bootstrap, Bootstrap 4, Bootstrap 5, High Contrast, Tailwind CSS | CDN, NPM |
     | React | .NET 5.0, .NET 6.0, and .NET 7.0 | Material, Fabric, Fluent, Bootstrap, Bootstrap 4, Bootstrap 5, High Contrast, Tailwind CSS | CDN, NPM |
 
-    > The Syncfusion ASP.NET Core (Essential JS 2) Project Template provides ASP.NET Core, Angular, and React project templates support from v17.1.0.47.
+    > The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential<sup style="font-size:70%">&reg;</sup> JS 2) Project Template provides ASP.NET Core, Angular, and React project templates support from v17.1.0.47.
 
     **.NET Core Version**: Select the version of ASP.NET Core Project.
 
     ![.net core version](images/net-core-version.png)
 
-    **Assets From**: Load the Syncfusion Essential JS 2 assets to ASP.NET Core Project, either NPM, CDN, or Installed Location.
+    **Assets From**: Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET Core Project, either NPM, CDN, or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
     **Theme Selection**: Themes will be listed out based on the selected project type and choose the required theme from the available list.
 
@@ -76,11 +76,11 @@ The following steps is used to create the **Syncfusion ASP.NET Core (Essential J
 
     ![authentication type](images/authentication.png)
 
-4. Click Create, the Syncfusion ASP.NET Core (Essential JS 2) Application has been created.
+4. Click Create, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 2) Application has been created.
 
     ![css refernce](images/readme-file.PNG)
 
-5. The required Syncfusion NuGet/NPM packages, Scripts, and CSS have been added to the Project.
+5. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet/NPM packages, Scripts, and CSS have been added to the Project.
 
     **Web App and Web App (Model-View-Controller):**
 
@@ -90,13 +90,13 @@ The following steps is used to create the **Syncfusion ASP.NET Core (Essential J
 
     **Angular:**
 
-    **NPM**: All the Syncfusion Angular NPM packages entries will be added in   package.json, it will automatically restore while build the application or save the  package.json file before compile the project.
+    **NPM**: All the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular NPM packages entries will be added in   package.json, it will automatically restore while build the application or save the  package.json file before compile the project.
 
     **Styles**: CSS entries will be added in index.html based on the selected .NET Core version.
 
     **React:**
 
-    **NPM**: All the Syncfusion React NPM packages entries will be added in package.json, it will automatically restore while build the application or save the package.json file before compile the project.
+    **NPM**: All the Syncfusion<sup style="font-size:70%">&reg;</sup>  React NPM packages entries will be added in package.json, it will automatically restore while build the application or save the package.json file before compile the project.
 
     **Styles**: CSS entries will be added in or index.html based on the selected project .Net Core version.
 
@@ -104,7 +104,7 @@ The following steps is used to create the **Syncfusion ASP.NET Core (Essential J
 
     ![css refernce](images/project-structure.png)
 
-6. Then, Syncfusion licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/whats-new-in-2018-volume-2-licensing-changes-in-the-1620x-version-of-essential-studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/whats-new-in-2018-volume-2-licensing-changes-in-the-1620x-version-of-essential-studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
     ![syncfusion license](images/syncfusion-license.png)
 

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/check-for-updates.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/check-for-updates.md
@@ -1,17 +1,17 @@
 ---
 layout: post
 title: Check for Updates | ASP.NET Core (Essential JS2) | Syncfusion
-description: Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio release.
+description: Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio  release.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Check for updates in Syncfusion ASP.NET Core
+# Check for updates in Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core
 
-Syncfusion provides the check for update extensions to find latest version of essential release was available, if it was available then provide option update most recent version of the Essential Studio release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
+Syncfusion provides the check for update extensions to find latest version of essential release was available, if it was available then provide option update most recent version of the Essential Studio<sup style="font-size:70%">&reg;</sup>  release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
 
-> The Syncfusion Check for updates is available from v17.1.0.32.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Check for updates is available from v17.1.0.32.
 
 You can check updates availability in Visual Studio, and then install the update version if required.
 
@@ -19,10 +19,10 @@ You can check updates availability in Visual Studio, and then install the update
 
     ![Check for updates](images/check-for-updates.png)
 
-    > From Visual Studio 2019, Choose Extensions > Syncfusion > Check for Updates… in the Visual Studio menu.
+    > From Visual Studio 2019, Choose Extensions > Syncfusion<sup style="font-size:70%">&reg;</sup>  > Check for Updates… in the Visual Studio menu.
 
 2. When there is an update, **Update** dialog box opens
 
     ![update](images/update.png)
 
-3. You can download the Syncfusion Essential Studio from the Syncfusion website by selecting **Download**.
+3. You can download the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  from the Syncfusion<sup style="font-size:70%">&reg;</sup>  website by selecting **Download**.

--- a/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/download-and-installation.md
+++ b/Extension/ASPNETCore-EssentialJS2-Extension/Visual-Studio/download-and-installation.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: Download and Installation | ASP.NET Core (Essential JS2) | Syncfusion
-description: How to download and install the Syncfusion ASP.NET Core (Essential JS2) Visual Studio Extensions from Visual Studio Market Place
+description: How to download and install the Syncfusion  ASP.NET Core (Essential JS2) Visual Studio Extensions from Visual Studio Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -14,7 +14,7 @@ Syncfusion publishes the Visual Studio extension in the [Visual Studio marketpla
 
 ## Prerequisites
 
-The following software prerequisites must be installed to install the Syncfusion ASP.NET Core extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion ASP.NET Core applications.
+The following software prerequisites must be installed to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core applications.
 
 * [Visual Studio 2019 or later](https://visualstudio.microsoft.com/downloads).
 
@@ -22,7 +22,7 @@ The following software prerequisites must be installed to install the Syncfusion
 
 ## Install through the Visual Studio Manage Extensions
 
-The steps below assist you to how to install the Syncfusion ASP.NET Core extensions from **Visual Studio Manage Extensions**.
+The steps below assist you to how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core extensions from **Visual Studio Manage Extensions**.
 
 1. Open the Visual Studio 2019.
 
@@ -44,13 +44,13 @@ The steps below assist you to how to install the Syncfusion ASP.NET Core extensi
 
 7. After the installation is complete, open Visual Studio 2019.
 
-8. Now, under the menu **Extensions**, you can use the Syncfusion extensions from the Visual Studio.
+8. Now, under the menu **Extensions**, you can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio.
 
     ![SyncfusionMenu](images/SyncfusionMenu.png)
 
 ## Install from the Visual Studio Marketplace
 
-The steps below illustrate how to download and install the Syncfusion ASP.NET Core extension from the Visual Studio Marketplace.
+The steps below illustrate how to download and install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core extension from the Visual Studio Marketplace.
 
 1. Download the [Syncfusion ASP.NET Core Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.ASPNETCoreExtensions) from the Visual Studio Marketplace.
 
@@ -62,6 +62,6 @@ The steps below illustrate how to download and install the Syncfusion ASP.NET Co
 
 4. Click the **Modify** button.
 
-5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion extensions from the Visual Studio under the **Extensions** menu.
+5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio under the **Extensions** menu.
 
      ![SyncfusionMenu](images/SyncfusionMenu.png)

--- a/Extension/ASPNETCore-Extension/Overview.md
+++ b/Extension/ASPNETCore-Extension/Overview.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: ASP.NET Core (Essential JS 1) Extension | Extension | Syncfusion
-description: An Extensions provide quick access to create or configure the Syncfusion ASP.NET Core projects along with Essential JS 1 components
+description: An Extensions provide quick access to create or configure the Syncfusion  ASP.NET Core projects along with Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -11,17 +11,17 @@ documentation: ug
 
 ## Overview
 
-The Syncfusion ASP.NET Core (Essential JS 1) Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.The Syncfusion ASP.NET Core Extensions supports Microsoft Visual Studio 2017.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Visual Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Extensions supports Microsoft Visual Studio 2017.
 
-I> The Syncfusion ASP.NET Core (Essential JS 1) menu option is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) menu option is available from v17.1.0.32.
 
-The Syncfusion provides the following extension supports in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the following extension supports in Visual Studio:
 
-1.	[Syncfusion ASP.NET Core (Essential JS 1) Project Template](https://help.syncfusion.com/extension/aspnetcore-extension/syncfusion-project-templates): To create the Syncfusion ASP.NET Core (Essential JS 1) application by adding the required Essential JS 1 components.
-2.	[Project Conversion](https://help.syncfusion.com/extension/aspnetcore-extension/project-conversion): To convert an existing ASP.NET Core application into a Syncfusion ASP.NET Core (Essential JS 1) Web application by adding the required Syncfusion assemblies and resource files.
-3.	[Migrate Project](https://help.syncfusion.com/extension/aspnetcore-extension/project-migration): Migrate the existing Syncfusion ASP.NET Core Web Application from one Essential Studio version to another version.
-4.	[Sample Creator](https://help.syncfusion.com/extension/aspnetcore-extension/sample-creator): Create the Syncfusion ASP.NET Core (Essential JS 1) Projects with the required Syncfusion configuration to start development with the required Syncfusion controls.
-5.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the Syncfusion configuration and apply the fix like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly.
+1.	[Syncfusion ASP.NET Core (Essential JS 1) Project Template](https://help.syncfusion.com/extension/aspnetcore-extension/syncfusion-project-templates): To create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) application by adding the required Essential JS 1 components.
+2.	[Project Conversion](https://help.syncfusion.com/extension/aspnetcore-extension/project-conversion): To convert an existing ASP.NET Core application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Web application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and resource files.
+3.	[Migrate Project](https://help.syncfusion.com/extension/aspnetcore-extension/project-migration): Migrate the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.
+4.	[Sample Creator](https://help.syncfusion.com/extension/aspnetcore-extension/sample-creator): Create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Projects with the required Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration to start development with the required Syncfusion<sup style="font-size:70%">&reg;</sup>  controls.
+5.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration and apply the fix like, wrong Framework Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly added to the project or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly.
 
 **No project selected in Visual Studio**
 
@@ -31,15 +31,15 @@ The Syncfusion provides the following extension supports in Visual Studio:
 
 ![Syncfusion Menu when Selected Microsoft ASP.NET Core application in Visual Studio](Overview_images/Syncfusion_Menu_OverView2.png)
 
-**Selected Syncfusion ASP.NET Core (Essential JS1) application in Visual Studio**
+**Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS1) application in Visual Studio**
 
 ![Syncfusion Menu when Selected Synfusion ASP.NET Core EJ1 application in Visual Studio](Overview_images/Syncfusion_Menu_OverView3.png)
 
-N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
-The Syncfusion ASP.NET Core Visual Studio Extensions are installed along with the following setups,
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Visual Studio Extensions are installed along with the following setups,
 
-* Essential Studio for Enterprise Edition with the platform ASP.NET Core
-* Essential Studio for ASP.NET Core
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platform ASP.NET Core
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET Core
 
 

--- a/Extension/ASPNETCore-Extension/Project-Conversion.md
+++ b/Extension/ASPNETCore-Extension/Project-Conversion.md
@@ -1,37 +1,37 @@
 ---
 layout: post
 title: Project Conversion | ASP.NET Core (Essential JS 1) | Syncfusion
-description: Project Conversion is a add-in that converts an existing ASP.NET Core project into Syncfusion ASP.NET Core project by adding required Essential JS 1 components
+description: Project Conversion is a add-in that converts an existing ASP.NET Core project into Syncfusion  ASP.NET Core project by adding required Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Conversion  
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion  
 
-Syncfusion Project Conversion is a Visual Studio add-in that converts an existing ASP.NET Core application into a Syncfusion ASP.NET Core Web application by adding the required assemblies and resource files.
+Syncfusion Project Conversion is a Visual Studio add-in that converts an existing ASP.NET Core application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web application by adding the required assemblies and resource files.
 
-I> The Syncfusion ASP.NET Core Web Application Project Conversion utility is available from v15.2.0.40. 
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application Project Conversion utility is available from v15.2.0.40. 
 
-## Convert into Syncfusion ASP.NET Core Web Application 
+## Convert into Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application 
 
-The following steps help you to use the Syncfusion Project Conversion in the existing ASP.NET Core Web Application.
+The following steps help you to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion in the existing ASP.NET Core Web Application.
 
-> Before use, the Syncfusion ASP.NET Core (Essential JS 1) Project Conversion, check whether the **Syncfusion Essential JS1 AspNet Core VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Conversion will not be shown.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Project Conversion, check whether the **Syncfusion Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet Core VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Conversion will not be shown.
 
 1. Open an existing Microsoft ASP.NET Core Web Application or create a new Microsoft ASP.NET Core Web Application. 
 
 2. To open Project Conversion Wizard, follow either one of the options below: 
 
    **Option 1:**  
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ1) > Convert to Syncfusion ASP.NET Core Application…** in **Visual Studio**.
+   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ1) > Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application…** in **Visual Studio**.
 
-   ![Syncfusion Essential JS 1 ASP.NET Core Project Conversion via Syncfusion menu](Project-Conversion_images/Syncfusion_Menu_Project_Conversion.png)
+   ![Syncfusion Essential JS 1 ASP.NET Core Project Conversion via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Project-Conversion_images/Syncfusion_Menu_Project_Conversion.png)
 
-   N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**  
-   Right-click the Project from Solution Explorer, select **Syncfusion Essential JS 1**, and then choose **Convert to Syncfusion ASP.NET Core (Essential JS 1) Application...** Refer to the following screenshot for more information.
+   Right-click the Project from Solution Explorer, select **Syncfusion Essential<sup style="font-size:70%">&reg;</sup> JS 1**, and then choose **Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Application...** Refer to the following screenshot for more information.
 
    ![Syncfusion Essential JS 1 ASP.NET Core Project Conversion add-in](Project-Conversion_images/Project-Conversion_img1.png)
 
@@ -43,15 +43,15 @@ The following steps help you to use the Syncfusion Project Conversion in the exi
 
    * Bower - Refer to the assets from Bower package manager. 
 
-   * CDN - Refer to the assets from Syncfusion CDN links.
+   * CDN - Refer to the assets from Syncfusion<sup style="font-size:70%">&reg;</sup>  CDN links.
 
-   * Installed Location - Refer to the assets from Syncfusion installed locations.     
+   * Installed Location - Refer to the assets from Syncfusion<sup style="font-size:70%">&reg;</sup>  installed locations.     
    
    ![Choose the required assets for Syncfusion Essential JS 1 ASP.NET Core project](Project-Conversion_images/Project-Conversion-img3.jpeg)
    
    **Choose the Theme:**
    
-   The master page of project will be updated based on selected theme. The Theme Preview section shows the controls preview before convert into a Syncfusion project
+   The master page of project will be updated based on selected theme. The Theme Preview section shows the controls preview before convert into a Syncfusion<sup style="font-size:70%">&reg;</sup>  project
    
    ![Choose the theme to apply on the master page of the ASP.NET Core project](Project-Conversion_images/Project-Conversion-img4.jpeg)
 
@@ -60,25 +60,25 @@ The following steps help you to use the Syncfusion Project Conversion in the exi
    The localization culture files will be shipped into Scripts\ej\i18n directory of the project.
 
    ![Choose Copy Global Resources to ship the localization culture files for ASP.NET Core project](Project-Conversion_images/Project-Conversion-img14.jpeg)  
-4. Choose the required controls from Components section and Click the **Convert** button to convert it into a Syncfusion Project.
+4. Choose the required controls from Components section and Click the **Convert** button to convert it into a Syncfusion<sup style="font-size:70%">&reg;</sup>  Project.
 
    ![Select the required components from the Components selection in the Syncfusion ASP.NET Core Project Conversion Wizard](Project-Conversion_images/ProjectConversion-img5.jpg)
    
-   The **Project Backup** dialog will be opened. If click Yes it will backup the current project before converting it to Syncfusion project. If click No it will convert the project to Syncfusion project without backup. 
+   The **Project Backup** dialog will be opened. If click Yes it will backup the current project before converting it to Syncfusion<sup style="font-size:70%">&reg;</sup>  project. If click No it will convert the project to Syncfusion<sup style="font-size:70%">&reg;</sup>  project without backup. 
    
    ![Syncfusion Essential JS 1 ASP.NET Core Project converson backup dialog](Project-Conversion_images/Project-Conversion-img6.jpg)
 
-5. The required Syncfusion NuGet/Bower packages, Scripts and CSS are included in the ASP.NET Core Web Application. Refer to the following screenshots for more information.
+5. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet/Bower packages, Scripts and CSS are included in the ASP.NET Core Web Application. Refer to the following screenshots for more information.
 
-   ![Required Syncfusion Essential JS 1 ASP.NET Core NuGet/Bower packages](Project-Conversion_images/Project-Conversion-img7.jpeg)
+   ![Required Syncfusion  Essential JS 1 ASP.NET Core NuGet/Bower packages](Project-Conversion_images/Project-Conversion-img7.jpeg)
 
-   ![Required Syncfusion Essential JS 1 ASP.NET Core themes and scripts](Project-Conversion_images/Project-Conversion-img8.jpeg)
+   ![Required Syncfusion  Essential JS 1 ASP.NET Core themes and scripts](Project-Conversion_images/Project-Conversion-img8.jpeg)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
    
-## Rendering Control after Syncfusion ASP.NET Core Conversion
+## Rendering Control after Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Conversion
 
-Once you converted your ASP.NET Core Web Application to Syncfusion ASP.NET Core Web Application using Syncfusion Visual Studio Extension, Perform the following steps to render the Syncfusion controls to your project.
+Once you converted your ASP.NET Core Web Application to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application using Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Extension, Perform the following steps to render the Syncfusion<sup style="font-size:70%">&reg;</sup>  controls to your project.
 
 1. Include the Syncfusion control snippets to any of the view page of your project. Refer the following screenshot for more information.
 

--- a/Extension/ASPNETCore-Extension/Project-Migration.md
+++ b/Extension/ASPNETCore-Extension/Project-Migration.md
@@ -1,39 +1,39 @@
 ---
 layout: post
 title: Project Migration | ASP.NET Core (Essential JS 1) | Syncfusion
-description: Project Migration is a add-in that allows you to migrate existing Syncfusion ASP.NET Core Web Application from one Essential Studio version to another version
+description: Project Migration is a add-in that allows you to migrate existing Syncfusion ASP.NET Core Web Application from one Essential Studio  version to another version
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Migration for ASP.NET Core Web Application
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Migration for ASP.NET Core Web Application
 
-Syncfusion Project Migration is a Visual Studio add-in that allows you to migrate the existing Syncfusion ASP.NET Core Web Application from one Essential Studio version to another version.
+Syncfusion Project Migration is a Visual Studio add-in that allows you to migrate the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.
 
-I> The Syncfusion ASP.NET Core Web Application Project Migration utility is available from v15.2.0.40.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application Project Migration utility is available from v15.2.0.40.
 
-## Migrate Syncfusion Project 
+## Migrate Syncfusion<sup style="font-size:70%">&reg;</sup>  Project 
 
-The following steps help you to migrate your existing Syncfusion ASP.NET Core Web Application. 
+The following steps help you to migrate your existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application. 
 
-> Before use, the Syncfusion ASP.NET Core (Essential JS 1) Project Migration, check whether the **Syncfusion Essential JS1 AspNet Core VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Migration will not be shown.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Project Migration, check whether the **Syncfusion Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet Core VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Migration will not be shown.
 
 1. To open Migration Wizard, follow either one of the options below: 
 
    **Option 1:**  
    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ1) > Migrate Project…** in **Visual Studio**.
    
-   ![Syncfusion Essential JS 1 ASP.NET Core Project Migration via Syncfusion menu](Project-Migration_images/Syncfusion_Menu_Project_Migration.png)
+   ![Syncfusion Essential JS 1 ASP.NET Core Project Migration via Syncfusion  menu](Project-Migration_images/Syncfusion_Menu_Project_Migration.png)
 
-   N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
    
    **Option 2:**  
-   Right-click the **Syncfusion ASP.NET Core Web Application** from Solution Explorer and select **Syncfusion Essential JS 1**. Choose **Migrate the Essential JS 1 Project to Another Version...**
+   Right-click the **Syncfusion ASP.NET Core Web Application** from Solution Explorer and select **Syncfusion Essential<sup style="font-size:70%">&reg;</sup> JS 1**. Choose **Migrate the Essential<sup style="font-size:70%">&reg;</sup> JS 1 Project to Another Version...**
 
    ![Syncfusion Essential JS 1 ASP.NET Core Project Migration add-in](Project-Migration_images/Project-Migration_img1.png)
 
-2. The **Project Migration** window appears. You can choose the required Essential Studio version that is installed in the machine. 
+2. The **Project Migration** window appears. You can choose the required Essential Studio<sup style="font-size:70%">&reg;</sup>  version that is installed in the machine. 
 
    ![Syncfusion Essential JS 1 ASP.NET Core Project Migration window](Project-Migration_images/Project-Migration-img2.jpeg)
 
@@ -41,12 +41,12 @@ The following steps help you to migrate your existing Syncfusion ASP.NET Core We
 
    i. **Essential Studio Version:** Select any version from the list of installed versions.
    
-   ii. **Assets From:** Load the Syncfusion assets to ASP.NET Core Project, either Bower, CDN or Installed Location.
+   ii. **Assets From:** Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  assets to ASP.NET Core Project, either Bower, CDN or Installed Location.
    
-4. Click the Migrate Button. The **Project Backup** dialog will be opened. If click Yes it will backup the current project before migrate the Syncfusion project. If click No it will migrate the project to required Syncfusion version without backup
+4. Click the Migrate Button. The **Project Backup** dialog will be opened. If click Yes it will backup the current project before migrate the Syncfusion<sup style="font-size:70%">&reg;</sup>  project. If click No it will migrate the project to required Syncfusion<sup style="font-size:70%">&reg;</sup>  version without backup
    
    ![Syncfusion Essential JS 1 ASP.NET Core Project Migration backup dialog](Project-Migration_images/Project-Migration-img3.jpeg)
       
-5. The Syncfusion NuGet/Bower Packages, Scripts and CSS are updated to the corresponding version in the project.
+5. The Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet/Bower Packages, Scripts and CSS are updated to the corresponding version in the project.
 
-6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.

--- a/Extension/ASPNETCore-Extension/Sample-Creator.md
+++ b/Extension/ASPNETCore-Extension/Sample-Creator.md
@@ -3,42 +3,42 @@ layout: post
 title: Sample Creator | ASP.NET Core (Essential JS 1) | Syncfusion
 description: Sample Creator is the utility that allows you to create Syncfusion ASP.NET Core Projects along with the samples based on Controls and Features selection
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Sample Creator
 
-Sample Creator is the utility that allows you to create Syncfusion ASP.NET Core Projects along with the samples based on Controls and Features selection.
+Sample Creator is the utility that allows you to create Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Projects along with the samples based on Controls and Features selection.
 
-I> The Syncfusion ASP.NET Core Sample Creator utility is available from v15.2.0.40.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Sample Creator utility is available from v15.2.0.40.
 
-## Create Syncfusion ASP.NET Core Web Application from Sample Creator
+## Create Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application from Sample Creator
 
-The following steps help you to create the Syncfusion ASP.NET Core Web Application via the Sample Creator utility.
+The following steps help you to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application via the Sample Creator utility.
 
-1. To launch ASP.NET Core (Essential JS 1) Sample Creator application, follow either one of the options below: 
+1. To launch ASP.NET Core (Essential<sup style="font-size:70%">&reg;</sup> JS 1) Sample Creator application, follow either one of the options below: 
 
    **Option 1:**   
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ1) > Launch Sample Creator…** in **Visual Studio**.
+   Click **Syncfusion<sup style="font-size:70%">&reg;</sup> Menu** and choose **Essential Studio<sup style="font-size:70%">&reg;</sup> for ASP.NET Core (EJ1) > Launch Sample Creator…** in **Visual Studio**.
    
    ![launch the Sample Creator via Syncfusion menu](Sample-Creator_images/Syncfusion_Menu_SampleCreator.png)
 
-   N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**  
-   Launch the Syncfusion ASP.NET Core (Essential JS 1) Control Panel. Select the Sample Creator button to launch the ASP.NET Core (Essential JS 1) Sample Creator application. Refer to the following screenshot for more information.
+   Launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential<sup style="font-size:70%">&reg;</sup> JS 1) Control Panel. Select the Sample Creator button to launch the ASP.NET Core (Essential JS 1) Sample Creator application. Refer to the following screenshot for more information.
 
    ![Syncfusion Essential Studio Essential JS 1 ASP.NET Core control panel to launch the Sample Creator](Sample-Creator_images/SampleCreator-img1.png)
 
-2. Syncfusion Sample Creator Wizard displaying the **Controls and its Feature Selection** section
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  Sample Creator Wizard displaying the **Controls and its Feature Selection** section
 
    ![Syncfusion Essential JS 1 ASP.NET Core Sample Creator wizard](Sample-Creator_images/SampleCreator-img2.jpeg)
 
 
 ### Controls Selection
 
-Listed here are the Syncfusion ASP.NET Core controls so you can choose the required controls.
+Listed here are the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core controls so you can choose the required controls.
 
    ![Syncfusion Essential JS 1 ASP.NET Core Sample Creator Controls selection](Sample-Creator_images/SampleCreator-img3.jpeg)
 
@@ -61,30 +61,30 @@ Based on the controls, the Feature is enabled to choose the features of the corr
 
    * .NET Framework – Choose the .NET Framework version.
    
-   * Assets From – Load the Syncfusion assets to ASP.NET Core Project, either Bower, CDN or Installed Location.
+   * Assets From – Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  assets to ASP.NET Core Project, either Bower, CDN or Installed Location.
 
-   * Name – Name your Syncfusion ASP.NET Core Application.
+   * Name – Name your Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application.
 
    * Location – Choose the target location of your project.
 
-   * Theme Selection – Choose the required theme.The Theme Preview section shows the controls preview before create the Syncfusion project.
+   * Theme Selection – Choose the required theme.The Theme Preview section shows the controls preview before create the Syncfusion<sup style="font-size:70%">&reg;</sup>  project.
 
    ![Syncfusion Essential JS 1 ASP.NET Core Sample Creator project configuration section](Sample-Creator_images/SampleCreator-img6.jpeg)
 
 
-2. When you click the Create button, the new Syncfusion ASP.NET Core project is created. The following resources are added in the project:
+2. When you click the Create button, the new Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core project is created. The following resources are added in the project:
 
    * Added the required View(.cshtml) and Class files in the project.
 
      ![Required View and Class files add in the project for the chosen controls](Sample-Creator_images/SampleCreator-img7.jpeg)
 
-   * Included the required Syncfusion scripts and themes files.
+   * Included the required Syncfusion<sup style="font-size:70%">&reg;</sup>  scripts and themes files.
 
      ![Required scripts and themes files included in the project](Sample-Creator_images/SampleCreator-img8.jpeg)
 
-   * Restored the required Syncfusion NuGet/Bower packages for selected controls under dependencies.
+   * Restored the required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet/Bower packages for selected controls under dependencies.
 
-     ![Required NuGet/Bower packages restored for the selected Syncfusion Essential JS 1 ASP.NET Core controls](Sample-Creator_images/SampleCreator-img9.jpeg)
+     ![Required NuGet/Bower packages restored for the selected Syncfusion  Essential JS 1 ASP.NET Core controls](Sample-Creator_images/SampleCreator-img9.jpeg)
 
 3. Once the project is created you can open the project by clicking the Yes button. If you click No button the corresponding location of the project will be opened. Refer the following screenshot for more information.
 

--- a/Extension/ASPNETCore-Extension/Syncfusion-Project-Templates.md
+++ b/Extension/ASPNETCore-Extension/Syncfusion-Project-Templates.md
@@ -1,43 +1,43 @@
 ---
 layout: post
 title: Project Templates | ASP.NET Core (Essential JS 1) | Syncfusion
-description: Syncfusion provides Visual Studio Project Templates for ASP.NET Core platform to create the Syncfusion ASP.NET Core Application using Essential JS 1 components
+description: Syncfusion  provides Visual Studio Project Templates for ASP.NET Core platform to create the Syncfusion ASP.NET Core Application using Essential JS 1 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Templates
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates
 
-Syncfusion provides the **Visual** **Studio** **Project** **Templates** for the Syncfusion ASP.NET Core platform to create Syncfusion ASP.NET Core Web Application.  
+Syncfusion provides the **Visual** **Studio** **Project** **Templates** for the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core platform to create Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Web Application.  
 
-I> The Syncfusion ASP.NET Core project templates are available from v15.2.0.40.  
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core project templates are available from v15.2.0.40.  
 
-## Create Syncfusion ASP.NET Core Application
+## Create Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application
 
 The following steps help you to create the **Syncfusion** **ASP****.****NET** **Core** **Application** through the **Visual** **Studio** **Project** **Template**.
 
-> Before use the Syncfusion ASP.NET Core (Essential JS 1) Project Template, check whether the **Syncfusion Essential JS1 AspNet Core VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Project Template, check whether the **Syncfusion Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet Core VSExtensions** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
 
-1. To create a Syncfusion ASP.NET Core (Essential JS 1) project, follow either one of the options below:
+1. To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) project, follow either one of the options below:
 
    **Option 1:**   
-   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ1) > Create New Syncfusion Project…** in **Visual Studio**.
+   Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET Core (EJ1) > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** in **Visual Studio**.
 
-   ![Choose Syncfusion ASP.NET Core Application from Visual Studio New Project dialog via Syncfusion menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate.png)
+   ![Choose Syncfusion  ASP.NET Core Application from Visual Studio New Project dialog via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate.png)
 
-   N>In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N>In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**   
-   Choose **File > New > Project** and navigate to **Syncfusion > .NET Core > Syncfusion ASP.NET Core (Essential JS 1) Web Application** in **Visual Studio**.
+   Choose **File > New > Project** and navigate to **Syncfusion > .NET Core > Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core (Essential JS 1) Web Application** in **Visual Studio**.
 
    ![Choose Syncfusion ASP.NET Core Application from Visual Studio New Project dialog](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates_img1.png)
 
 2. Name the **Project**, choose the destination location when required and set the Framework of the project, then click **OK**. The Project Configuration Wizard appears.
 
-   N> Minimum target Framework is 4.5.2 for Syncfusion ASP.NET Core Project Templates.
+   N> Minimum target Framework is 4.5.2 for Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Project Templates.
    
-3. Choose the options to configure the Syncfusion ASP.NET Core Application by using the following Project Configuration dialog.
+3. Choose the options to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application by using the following Project Configuration dialog.
 
    ### Project configurations:
 
@@ -45,24 +45,24 @@ The following steps help you to create the **Syncfusion** **ASP****.****NET** **
 
    **.NET Core Version:** Select the version of ASP.NET Core Project, either ASP.NET Core 1.0 or ASP.NET Core 1.1.
 
-   **Assets From:** Load the Syncfusion assets to ASP.NET Core Project, either Bower, CDN or Installed Location.
+   **Assets From:** Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  assets to ASP.NET Core Project, either Bower, CDN or Installed Location.
 
    **Theme Selection:** Choose the required Theme.
 
-   **Components:** Choose the Required Syncfusion components to configure.
+   **Components:** Choose the Required Syncfusion<sup style="font-size:70%">&reg;</sup>  components to configure.
 
    ![Syncfusion Essential JS 1 ASP.NET Core Project Configuration wizard](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img2.jpeg)
    
-4. Once you click Create button, the Syncfusion ASP.NET Core Application is created.
+4. Once you click Create button, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Application is created.
 
-5. Required Syncfusion NuGet/Bower packages, Scripts and CSS are added to the Project.
+5. Required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet/Bower packages, Scripts and CSS are added to the Project.
 
-   ![Required Syncfusion NuGet/Bower packages added to the Syncfusion Essential JS 1 ASP.NET Core project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img3.jpeg)
+   ![Required Syncfusion NuGet/Bower packages added to the Syncfusion  Essential JS 1 ASP.NET Core project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img3.jpeg)
 
-   ![Required Syncfusion Scripts and Themes added to the Syncfusion Essential JS 1 ASP.NET Core project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img4.jpeg)
+   ![Required Syncfusion Scripts and Themes added to the Syncfusion  Essential JS 1 ASP.NET Core project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img4.jpeg)
 
-6. Then, Syncfusion licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-   ![Syncfusion license registration information for Syncfusion Essential JS 1 ASP.NET Core project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img5.jpeg)   
+   ![Syncfusion license registration information for Syncfusion  Essential JS 1 ASP.NET Core project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img5.jpeg)   
 
 

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/Overview.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/Overview.md
@@ -1,31 +1,31 @@
 ---
 layout: post
 title: ASP.NET MVC (Essential JS 2) Extension | Extension | Syncfusion
-description: Syncfusion ASP.NET MVC (Essential JS2) Extensions create or configure the Syncfusion ASP.NET MVC projects along with Essential JS2 components.
+description: Syncfusion  ASP.NET MVC (Essential JS2) Extensions create or configure the Syncfusion  ASP.NET MVC projects along with Essential JS2 components.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# ASP.NET MVC (Essential JS 2) Extension
+# ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup>  JS 2) Extension
 
-The Syncfusion ASP.NET MVC (Essential JS 2) Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup>  JS 2) Visual Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.
 
-> Syncfusion Extension is published in the Visual Studio Marketplace. Refer to the following link.
+> Syncfusion<sup style="font-size:70%">&reg;</sup>  Extension is published in the Visual Studio Marketplace. Refer to the following link.
 <https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.ASPNETMVCExtensions>
 
 ## IMPORTANT
 
-The Syncfusion ASP.NET MVC (Essential JS 2) menu option is available from v17.1.0.32.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup>  JS 2) menu option is available from v17.1.0.32.
 Syncfusion provides the following supports in Visual Studio:
 
-[Project Template](syncfusion-project-templates): Creates the Syncfusion ASP.NET MVC (Essential JS 2) application by adding the required Essential JS 2 components.
+[Project Template](syncfusion-project-templates): Creates the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) application by adding the required Essential<sup style="font-size:70%">&reg;</sup> JS 2 components.
 
-[Convert Project](project-conversion): Converts an existing ASP.NET MVC application into a Syncfusion ASP.NET MVC (Essential JS 2) application by adding the required Syncfusion assemblies and resource files.
+[Convert Project](project-conversion): Converts an existing ASP.NET MVC application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and resource files.
 
-[Upgrade Project](project-migration): Upgrades the existing Syncfusion ASP.NET MVC (Essential JS 2) application from one Essential Studio version to another version.
+[Upgrade Project](project-migration): Upgrades the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.
 
-[Creator Sample](sample-creator): Creates the Syncfusion ASP.NET MVC (Essential JS2) application with the sample code of required controls and features.
+[Creator Sample](sample-creator): Creates the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS2) application with the sample code of required controls and features.
 
 ### No project selected in Visual Studio
 
@@ -35,8 +35,8 @@ Syncfusion provides the following supports in Visual Studio:
 
 ![selected microsoft aspmvc](images/selected-microsoft-mvc-application.png)
 
-### Selected Syncfusion ASP.NET MVC (Essential JS2) application in Visual Studio
+### Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS2) application in Visual Studio
 
 ![selected syncfusion aspnetmvc](images/selected-syncfusion-mvc-application.png)
 
-> From Visual Studio 2019, Syncfusion menu is available under Extension in Visual Studio menu.
+> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extension in Visual Studio menu.

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/Project-Conversion.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/Project-Conversion.md
@@ -1,55 +1,55 @@
 ---
 layout: post
 title: Project Conversion | ASP.NET MVC (Essential JS 2) | Syncfusion
-description: Project Conversion is a add-in that converts an existing ASP.NET MVC project into a Syncfusion ASP.NET MVC project by adding required Essential JS 2 components
+description: Project Conversion is a add-in that converts an existing ASP.NET MVC project into a Syncfusion  ASP.NET MVC project by adding required Essential JS 2 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Conversion
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion
 
-Syncfusion ASP.NET MVC conversion is a Visual Studio add-in that converts an existing ASP.NET MVC application into a Syncfusion ASP.NET MVC (Essential JS 2) Web application by adding the required assemblies and resource files.
+Syncfusion ASP.NET MVC conversion is a Visual Studio add-in that converts an existing ASP.NET MVC application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Web application by adding the required assemblies and resource files.
 
-> The Syncfusion ASP.NET MVC (Essential JS 2) Web Application Project conversion utility is available from v16.3.0.17. Before use, the Syncfusion ASP.NET MVC Project Conversion, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Conversion will not be shown.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential<sup style="font-size:70%">&reg;</sup>  JS 2) Web Application Project conversion utility is available from v16.3.0.17. Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project Conversion, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Conversion will not be shown.
 
-The steps below help you to convert the ASP.NET MVC application to the Syncfusion ASP.NET MVC application via the Visual Studio 2019:
+The steps below help you to convert the ASP.NET MVC application to the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC application via the Visual Studio 2019:
 
 1. Open an existing Microsoft ASP.NET MVC Web Application or create a new Microsoft ASP.NET MVC Web Application.
 
-2. To open the Syncfusion Project Conversion Wizard, follow either one of the options below:
+2. To open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion Wizard, follow either one of the options below:
 
     **Option 1:**
 
-    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC > Convert to Syncfusion ASP.NET MVC Application…** in **Visual Studio Menu**.
+    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC > Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Application…** in **Visual Studio Menu**.
 
     ![convert-to-syncfusion](images/convert-project.png)
 
-    > From Visual Studio 2019, Syncfusion menu is available under **Extensions** in Visual Studio menu.
+    > From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under **Extensions** in Visual Studio menu.
 
     **Option 2:**
 
-    Right-click the **Project** from Solution Explorer, select **Syncfusion Web**, and choose the **Convert to Syncfusion ASP.NET MVC Application…** Refer to the following screenshot for more information.
+    Right-click the **Project** from Solution Explorer, select **Syncfusion Web**, and choose the **Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Application…** Refer to the following screenshot for more information.
 
     ![syncfusion-aspnet mvc](images/convert-syncfusion-aspmvc-application.png)
 
-3. The Syncfusion ASP.NET MVC Project Conversion window will appear. You can choose the required version of Syncfusion ASP.NET MVC, Assets from, and Themes to convert the application.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project Conversion window will appear. You can choose the required version of Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC, Assets from, and Themes to convert the application.
 
     ![project conversion wizard](images/project-conversion-wizard.png)
 
-    > The versions are loaded from the Syncfusion ASP.NET MVC NuGet packages which published in [NuGet.org](https://www.nuget.org/packages?q=Tags%3A%22aspnetmvc%22syncfusion) and it requires internet connectivity.
+    > The versions are loaded from the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC NuGet packages which published in [NuGet.org](https://www.nuget.org/packages?q=Tags%3A%22aspnetmvc%22syncfusion) and it requires internet connectivity.
 
     The following configurations are used in the Project conversion wizard.
 
-    **Assets From**: Load the Syncfusion Essential JS 2 assets to ASP.NET MVC Project, from either NuGet, CDN, or Installed Location.
+    **Assets From**: Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET MVC Project, from either NuGet, CDN, or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
     **Choose the Theme**: Choose the required theme.
 
 4. Check the **“Enable a backup before converting”** checkbox if you want to take the project backup and choose the location.
 
-5. The required Syncfusion NuGet packages, Scripts and CSS are included in the ASP.NET MVC Web Application. Refer to the following screenshots for more information.
+5. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, Scripts and CSS are included in the ASP.NET MVC Web Application. Refer to the following screenshots for more information.
 
     ![syncfusion assemblies](images/syncfusion-reference.png)
 
@@ -61,4 +61,4 @@ The steps below help you to convert the ASP.NET MVC application to the Syncfusio
 
     ![BackupLocation](images/BackupLocation.png)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/Project-Migration.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/Project-Migration.md
@@ -1,25 +1,25 @@
 ---
 layout: post
 title: Project Migration | ASP.NET MVC (Essential JS 2) | Syncfusion
-description: Project Migration is a add-in that allows you to migrate the existing Syncfusion ASP.NET MVC Application from one Essential Studio version to another version
+description: Project Migration is a add-in that allows you to migrate the existing Syncfusion  ASP.NET MVC Application from one Essential Studio  version to another version
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Upgrading Syncfusion ASP.NET MVC application to latest version
+# Upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC application to latest version
 
-The Syncfusion ASP.NET MVC migration add-in for Visual Studio allows you to migrate an existing Syncfusion ASP.NET MVC application from one version of Essential Studio version to another version. This reduces the amount of manual work required when migrating the Syncfusion version.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC migration add-in for Visual Studio allows you to migrate an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC application from one version of Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version. This reduces the amount of manual work required when migrating the Syncfusion<sup style="font-size:70%">&reg;</sup>  version.
 
 ## IMPORTANT
 
-The Syncfusion ASP.NET MVC (Essential JS 2) Web Application Project Migration utility is available from v16.3.0.17.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Web Application Project Migration utility is available from v16.3.0.17.
 
-> Before use, the Syncfusion ASP.NET MVC Project Migration, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio version build installed or not. If the Essential Studio version is not same for both the Extension and build, then the Project Migration will not be shown.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project Migration, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/download-and-installation) help topic. Also, check whether the corresponding Essential Studio<sup style="font-size:70%">&reg;</sup>  version build installed or not. If the Essential Studio<sup style="font-size:70%">&reg;</sup>  version is not same for both the Extension and build, then the Project Migration will not be shown.
 
-The steps below will assist you to upgrade the Syncfusion version in the Syncfusion ASP.NET MVC application via Visual Studio 2019:
+The steps below will assist you to upgrade the Syncfusion<sup style="font-size:70%">&reg;</sup>  version in the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC application via Visual Studio 2019:
 
-1. Open the Syncfusion ASP.NET MVC application that uses the Syncfusion component.
+1. Open the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC application that uses the Syncfusion<sup style="font-size:70%">&reg;</sup>  component.
 
 2. To open the Migration Wizard, either one of the following options should be followed:
 
@@ -27,30 +27,30 @@ The steps below will assist you to upgrade the Syncfusion version in the Syncfus
 
     ![migrate project](images/migrate-project.png)
 
-    > From Visual Studio 2019, Syncfusion menu is available under **Extensions** in Visual Studio menu.
+    > From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under **Extensions** in Visual Studio menu.
 
     **Option 2**:
 
-    Right-click the **Syncfusion ASP.NET MVC Application** from Solution Explorer and select **Syncfusion Web**. Choose **Migrate the Syncfusion ASP.NET MVC Project to Another Version…**
+    Right-click the **Syncfusion ASP.NET MVC Application** from Solution Explorer and select **Syncfusion Web**. Choose **Migrate the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project to Another Version…**
 
     ![migrate the essential js2](images/migrate-essentialJs2.png)
 
-3. The Syncfusion Project Migration window will appear. You can choose the required version of Syncfusion ASP.NET MVC to migrate.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Migration window will appear. You can choose the required version of Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC to migrate.
 
     ![project migration](images/project-migration.png)
 
-    > The versions are loaded from the Syncfusion ASP.NET MVC NuGet packages which published in [NuGet.org](https://www.nuget.org/packages?q=Tags%3A%22aspnetmvc%22syncfusion) and it requires internet connectivity.
+    > The versions are loaded from the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC NuGet packages which published in [NuGet.org](https://www.nuget.org/packages?q=Tags%3A%22aspnetmvc%22syncfusion) and it requires internet connectivity.
 
-    **Assets From:** Load the Syncfusion Essential JS 2 assets to ASP.NET MVC Project, from either NuGet, CDN or Installed Location.
+    **Assets From:** Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET MVC Project, from either NuGet, CDN or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
 4. Check the **“Enable a backup before migrating”** checkbox if you want to take the project backup and choose location.
 
-5. The Syncfusion Reference Assemblies, Scripts, and CSS are updated to the selected version in the project.
+5. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Assemblies, Scripts, and CSS are updated to the selected version in the project.
 
     if you enabled project backup before migrating, the old project was saved in the specified backup path location, as shown below once the migration process completed
 
     ![BackupLocation](images/BackupLocation.png)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/Sample-Creator.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/Sample-Creator.md
@@ -1,19 +1,19 @@
 ---
 layout: post
 title: Sample Creator | ASP.NET MVC (Essential JS 2) | Syncfusion
-description: Sample Creator is a utility that allows you to create the Syncfusion ASP.NET MVC (Essential JS 2) Projects with required Syncfusion controls
+description: Sample Creator is a utility that allows you to create the Syncfusion  ASP.NET MVC (Essential JS 2) Projects with required Syncfusion  controls
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
 ---
 
-# Creating Syncfusion ASP.NET MVC application
+# Creating Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC application
 
-The Syncfusion Sample Creator is a tool that lets you make Syncfusion ASP.NET MVC (Essential JS 2) projects with sample code for required Syncfusion component features and Syncfusion control configuration.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Sample Creator is a tool that lets you make Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) projects with sample code for required Syncfusion<sup style="font-size:70%">&reg;</sup>  component features and Syncfusion<sup style="font-size:70%">&reg;</sup>  control configuration.
 
-> The Syncfusion ASP.NET MVC (Essential JS 2) Sample Creator utility is available from v16.3.0.17.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Sample Creator utility is available from v16.3.0.17.
 
-Use the following steps to create the Syncfusion ASP.NET MVC (Essential JS 2) Application through the Sample Creator utility:
+Use the following steps to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Application through the Sample Creator utility:
 
 1. Follow one of the options below to launch the ASP.NET MVC (Essential JS 2) Sample Creator application:
 
@@ -23,15 +23,15 @@ Use the following steps to create the Syncfusion ASP.NET MVC (Essential JS 2) Ap
 
     **Option 2:**
 
-    Launch the Syncfusion ASP.NET MVC (Essential JS 2) Control Panel. Select the Sample Creator button to launch the ASP.NET MVC (Essential JS 2) Sample Creator application. Refer to the following screenshot for more information.
+    Launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Control Panel. Select the Sample Creator button to launch the ASP.NET MVC (Essential JS 2) Sample Creator application. Refer to the following screenshot for more information.
 
     ![sample creator application](images/sample-creator-application.png)
 
-2. Syncfusion controls and features are listed in the ASP.NET MVC (Essential JS 2) Sample Creator.
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  controls and features are listed in the ASP.NET MVC (Essential JS 2) Sample Creator.
 
     ![sample creator lists](images/sample-creator-list.png)
 
-    **Controls Selection**: Choose the required controls. The controls are grouped with Syncfusion products.
+    **Controls Selection**: Choose the required controls. The controls are grouped with Syncfusion<sup style="font-size:70%">&reg;</sup>  products.
 
     ![control selection](images/control-selection.png)
 
@@ -47,17 +47,17 @@ Use the following steps to create the Syncfusion ASP.NET MVC (Essential JS 2) Ap
 
     * **VS Version**: Choose the Visual Studio version and Framework.
 
-    * **View Engine**: By default, Syncfusion supports only Razor view engine for ASP.NET MVC projects.
+    * **View Engine**: By default, Syncfusion<sup style="font-size:70%">&reg;</sup>  supports only Razor view engine for ASP.NET MVC projects.
 
-    * **Assets From**: Choose the Syncfusion Essential JS 2 assets to ASP.NET MVC Project, either NuGet, CDN or Installed Location.
+    * **Assets From**: Choose the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET MVC Project, either NuGet, CDN or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
-    * **Name**: Name your Syncfusion ASP.NET MVC (Essential JS 2) Application.
+    * **Name**: Name your Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Application.
 
     * **Location**: Choose the target location of your project.
 
-    * **Theme Selection**: Choose the required theme. This section shows the controls preview before creating the Syncfusion project.
+    * **Theme Selection**: Choose the required theme. This section shows the controls preview before creating the Syncfusion<sup style="font-size:70%">&reg;</sup>  project.
 
     ![sample creator theme selection](images/aspnet-mvc-samplecreator.png)
 
@@ -65,16 +65,16 @@ Use the following steps to create the Syncfusion ASP.NET MVC (Essential JS 2) Ap
 
     ![create](images/sample-creator-create.png)
 
-3. The new Syncfusion ASP.NET MVC (Essential JS 2) project is created with the resources.
+3. The new Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) project is created with the resources.
 
     * Added the required Controllers and View files in the project.
 
         ![required controllers](images/required-controllers.png)
 
-    * Included the required Syncfusion ASP.NET MVC (Essential JS 2) scripts and theme files.
+    * Included the required Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) scripts and theme files.
 
         ![script-theme references](images/scripts-theme.png)
 
-    * The required Syncfusion assemblies are added for selected controls under Project Reference.
+    * The required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies are added for selected controls under Project Reference.
 
         ![syncfusion assemblies](images/syncfusion-assemblies.png)

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/Scaffolding.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/Scaffolding.md
@@ -1,21 +1,21 @@
 ---
 layout: post
 title: Scaffolding | ASP.NET MVC (Essential JS 2) | Syncfusion
-description: Code-generation Framework for Syncfusion ASP.NET MVC platform to quickly create the Controller and Views in a short time.
+description: Code-generation Framework for Syncfusion  ASP.NET MVC platform to quickly create the Controller and Views in a short time.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # ASP.NET MVC Scaffolding
 
-Syncfusion provides **Visual Studio Scaffolding**for Syncfusion ASP.NET MVC platform to quickly add code that interacts with data models and reduce the amount of time to develop with data operation in your project. Scaffolding provides an easier way to create Views and Controller action methods for Syncfusion ASP.NET MVC DataGrid, Charts, and Scheduler controls.
+Syncfusion provides **Visual Studio Scaffolding**for Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC platform to quickly add code that interacts with data models and reduce the amount of time to develop with data operation in your project. Scaffolding provides an easier way to create Views and Controller action methods for Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC DataGrid, Charts, and Scheduler controls.
 
-> The Syncfusion ASP.NET MVC UI Scaffolder is available from v16.4.0.40.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC UI Scaffolder is available from v16.4.0.40.
 
 The following steps explain you how to add a scaffolded item to your ASP.NET MVC Web application.
 
-> Before use, the Syncfusion ASP.NET MVC Scaffolding, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/VS2019-Extensions/download-and-installation/) help topic.
+> Before use, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Scaffolding, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/VS2019-Extensions/download-and-installation/) help topic.
 
 1. Right-click the **Controllers** folder in the Solution Explorer, click **Add**, and then select **New Scaffolded Item**.
 
@@ -25,27 +25,27 @@ The following steps explain you how to add a scaffolded item to your ASP.NET MVC
 
     ![syncfusion aspnetmvc ui scaffolder](images/mvc-ui-scaffolder.png)
 
-3. In the Syncfusion UI Scaffolding dialog, select the desired control to perform scaffolding, and then click **Next**.
+3. In the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolding dialog, select the desired control to perform scaffolding, and then click **Next**.
 
     ![syncfusion ui scaffolding](images/syncfusion-ui-scaffolding.png)
 
-4. Selected control model dialogue will be launched in the Syncfusion UI Scaffolder. Enter the **Controller Name** and **View Name** as application requirements, and then select the required **Model Class** of the active project and its relevant **Data Context Class**, and then click **Next**.
+4. Selected control model dialogue will be launched in the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder. Enter the **Controller Name** and **View Name** as application requirements, and then select the required **Model Class** of the active project and its relevant **Data Context Class**, and then click **Next**.
 
     ![syncfusion ui scaffolding for datagrid](images/ui-scaffolding-datagrid.png)
 
-5. Selected control feature dialogue will be launched in the Syncfusion UI Scaffolder. Select the required features, update the required data field, and then click **Add**.
+5. Selected control feature dialogue will be launched in the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder. Select the required features, update the required data field, and then click **Add**.
 
     ![syncfusion scaffolding add button](images/scaffolding-add-button.png)
 
-6. The **Controller** and the corresponding **View** files are now generated with the selected features of Syncfusion control code snippet.
+6. The **Controller** and the corresponding **View** files are now generated with the selected features of Syncfusion<sup style="font-size:70%">&reg;</sup>  control code snippet.
 
     ![controllers](images/controllers-view.png)
 
-7. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion license key to your project since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+7. If you installed the trial setup or NuGet packages from nuget.org you have to register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
 > Ensure that at least one Entity Framework model exists, and the application has been compiled once. If no Entity Framework model exist in your application, refer to this [documentation](https://docs.microsoft.com/en-us/aspnet/mvc/overview/getting-started/database-first-development/creating-the-web-application#generate-the-models) to generate the Entity Framework model. After the model file has been added, ensure that the required DBContext and properties have been added. Now, build the application, and try scaffolding. If any changes have been done in the model properties, rebuild the application once before perform scaffolding.
 
-Refer to the following UG links to render Syncfusion control after performed scaffolding.
+Refer to the following UG links to render Syncfusion<sup style="font-size:70%">&reg;</sup>  control after performed scaffolding.
 
 MVC4: [Configure Essential JS 2 using Syncfusion.EJ2.MVC4 package](https://ej2.syncfusion.com/aspnetmvc/documentation/getting-started/visual-studio-2017/#configure-essential-js-2-in-the-application-1)
 

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/Syncfusion-Notifications.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications | ASP.NET MVC (Essential JS2) | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in ASP.NET MVC applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in ASP.NET MVC applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> ASP.NET MVC**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> ASP.NET MVC**
 
 ![Option Page](images/mvc-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your ASP.NET MVC application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your ASP.NET MVC application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/mvc-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/mvc-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio ASP.NET MVC - EJ2,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your ASP.NET MVC development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio ASP.NET MVC - EJ2,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your ASP.NET MVC development projects.
 
 ![Build Notification](images/mvc-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your ASP.NET MVC application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your ASP.NET MVC application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/mvc-invalid.png)
 

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/Syncfusion-Project-Templates.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/Syncfusion-Project-Templates.md
@@ -1,41 +1,41 @@
 ---
 layout: post
 title: Project Templates | ASP.NET MVC (Essential JS 2) | Syncfusion
-description: Syncfusion provides Visual Studio Project Templates for ASP.NET MVC platform to create the Syncfusion ASP.NET MVC Application using Essential JS 2 components
+description: Syncfusion  provides Visual Studio Project Templates for ASP.NET MVC platform to create the Syncfusion  ASP.NET MVC Application using Essential JS 2 components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Templates
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates
 
-Syncfusion provides the **Visual Studio Project Templates** for the Syncfusion ASP.NET MVC platform to create the Syncfusion ASP.NET MVC Web Application with the Essential JS 2 components.
+Syncfusion provides the **Visual Studio Project Templates** for the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC platform to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Web Application with the Essential JS 2 components.
 
-> The Syncfusion ASP.NET MVC (Essential JS 2) project templates are available from v16.2.0.41.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) project templates are available from v16.2.0.41.
 
 Use the following steps to create the **Syncfusion ASP.NET MVC (Essential JS 2) Web Application** through the **Visual Studio Project Template.**
 
-> Before use the Syncfusion ASP.NET MVC Project Template, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/download-and-installation) help topic.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Project Template, check whether the **ASP.NET MVC Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://ej2.syncfusion.com/aspnetmvc/documentation/visual-studio-integration/download-and-installation) help topic.
 
-1. To create the Syncfusion ASP.NET MVC (Essential JS 2) project, follow either one of the options below:
+1. To create the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) project, follow either one of the options below:
 
     **Option 1:**
 
-    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC (EJ2) > Create New Syncfusion Project…** in **Visual Studio 2019 earlier**.
+    Click **Syncfusion Menu** and choose **Essential Studio for ASP.NET MVC (EJ2) > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** in **Visual Studio 2019 earlier**.
 
     ![create new syncfusion project](images/new-syncfusion-project.png)
 
-    > From Visual Studio 2019, Syncfusion menu is available under Extension in Visual Studio menu.
+    > From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extension in Visual Studio menu.
 
     ![SyncfusionMenu](images/SyncfusionMenu.png)
 
     **Option 2:**
 
-    Choose **File > New > Project** and navigate to **Syncfusion > Web > Syncfusion ASP.NET MVC (Essential JS 2) Application** in **Visual Studio 2019 earlier**.
+    Choose **File > New > Project** and navigate to **Syncfusion > Web > Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Application** in **Visual Studio 2019 earlier**.
 
     ![syncfusion asp.net mvc](images/syncfusion-aspmvc-application.png)
 
-    > In Visual Studio 2019, Syncfusion ASP.NET MVC will be shown like below in solution explores.
+    > In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC will be shown like below in solution explores.
 
     ![Syncfusion MVC Project Wizard](images/SyncfusionMvcProjectWizard.png)
 
@@ -47,24 +47,24 @@ Use the following steps to create the **Syncfusion ASP.NET MVC (Essential JS 2) 
 
     **Target MVC Version**: Select the version of ASP.NET MVC Project, either MVC5 or MVC4.
 
-    **Theme Selection**: Choose the required Theme. The Theme Preview section shows the controls preview with selected theme before creating the Syncfusion project.
+    **Theme Selection**: Choose the required Theme. The Theme Preview section shows the controls preview with selected theme before creating the Syncfusion<sup style="font-size:70%">&reg;</sup>  project.
 
     ![theme selection](images/theme-selection.png)
 
-    **Assets From**: : Load the Syncfusion Essential JS 2 assets to ASP.NET MVC Project, either NuGet, CDN, or Installed Location.
+    **Assets From**: : Load the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS 2 assets to ASP.NET MVC Project, either NuGet, CDN, or Installed Location.
 
-    > Installed location option will be available only when the Syncfusion Essential JavaScript 2 setup has been installed.
+    > Installed location option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JavaScript 2 setup has been installed.
 
-3. Click **Create**, the Syncfusion ASP.NET MVC (Essential JS 2) Application will be created.
+3. Click **Create**, the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC (Essential JS 2) Application will be created.
 
     ![readme-file](images/readme-file.PNG)
 
-4. The required Syncfusion NuGet packages, Scripts, and CSS have been added to the project.
+4. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, Scripts, and CSS have been added to the project.
 
     ![nuget-package](images/nuget.png)
 
     ![css-script reference](images/css-scripts-reference.png)
 
-5. Then, the Syncfusion licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/whats-new-in-2018-volume-2-licensing-changes-in-the-1620x-version-of-essential-studio.aspx) post to learn more about the licensing changes introduced in Essential Studio.
+5. Then, the Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/whats-new-in-2018-volume-2-licensing-changes-in-the-1620x-version-of-essential-studio.aspx) post to learn more about the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
     ![syncfusion license](images/syncfusion-license.png)

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/check-for-updates.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/check-for-updates.md
@@ -1,17 +1,17 @@
 ---
 layout: post
 title: Check for Updates | ASP.NET MVC (Essential JS2) | Syncfusion
-description: Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio release.
+description: Syncfusion  Check for Updates provides Extensions to update most recent version of the Essential Studio  release.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Check for updates in Syncfusion ASP.NET MVC
+# Check for updates in Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC
 
-Syncfusion provides the check for update extensions to find latest version of essential release was available, if it was available then provide option update most recent version of the Essential Studio release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
+Syncfusion provides the check for update extensions to find latest version of essential<sup style="font-size:70%">&reg;</sup> release was available, if it was available then provide option update most recent version of the Essential Studio<sup style="font-size:70%">&reg;</sup>  release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
 
-> The Syncfusion Check for updates is available from v17.1.0.32.
+> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Check for updates is available from v17.1.0.32.
 
 You can check updates availability in Visual Studio, and then install the update version if required.
 
@@ -19,10 +19,10 @@ You can check updates availability in Visual Studio, and then install the update
 
     ![check for updates](images/check-for-updates.png)
 
-    > From Visual Studio 2019, Choose Extensions -> Syncfusion -> Check for updates… in the Visual Studio menu.
+    > From Visual Studio 2019, Choose Extensions -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Check for updates… in the Visual Studio menu.
 
 2. When there is an update, **Update** dialog box opens.
 
     ![update dialog](images/update-dialog.png)
 
-3. You can download the Syncfusion Essential Studio from the Syncfusion website by selecting **Download**.
+3. You can download the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  from the Syncfusion<sup style="font-size:70%">&reg;</sup>  website by selecting **Download**.

--- a/Extension/ASPNETMVC-EssentialJS2-Extension/download-and-installation.md
+++ b/Extension/ASPNETMVC-EssentialJS2-Extension/download-and-installation.md
@@ -3,7 +3,7 @@ layout: post
 title: Download and Installation | ASP.NET MVC (Essential JS2) | Syncfusion
 description: How to download and install the Syncfusion ASP.NET MVC (Essential JS2) Visual Studio Extensions from Visual Studio Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -14,13 +14,13 @@ Syncfusion publishes the Visual Studio extension in the [Visual Studio marketpla
 
 ## Prerequisites
 
-The following software prerequisites must be installed to install the Syncfusion ASP.NET MVC extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion ASP.NET MVC applications.
+The following software prerequisites must be installed to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC applications.
 
 * [Visual Studio 2013 or later](https://visualstudio.microsoft.com/downloads).
 
 ## Install through the Visual Studio Manage Extensions
 
-The steps below assist you to how to install the Syncfusion ASP.NET MVC extensions from **Visual Studio Manage Extensions**.
+The steps below assist you to how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC extensions from **Visual Studio Manage Extensions**.
 
 1. Open the Visual Studio 2019.
 
@@ -42,13 +42,13 @@ The steps below assist you to how to install the Syncfusion ASP.NET MVC extensio
 
 7. After the installation is complete, open Visual Studio 2019.
 
-8. Now, under the menu **Extensions**, you can use the Syncfusion extensions from the Visual Studio.
+8. Now, under the menu **Extensions**, you can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio.
 
     ![SyncfusionMenu](images/SyncfusionMenu.png)
 
 ## Install from the Visual Studio Marketplace
 
-The steps below illustrate how to download and install the Syncfusion ASP.NET MVC extension from the Visual Studio Marketplace.
+The steps below illustrate how to download and install the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC extension from the Visual Studio Marketplace.
 
 1. Download the [Syncfusion ASP.NET MVC Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.ASPNETMVCExtensions) from the Visual Studio Marketplace.
 
@@ -60,6 +60,6 @@ The steps below illustrate how to download and install the Syncfusion ASP.NET MV
 
 4. Click the **Modify** button.
 
-5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion extensions from the Visual Studio under the **Extensions** menu.
+5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio under the **Extensions** menu.
 
      ![SyncfusionMenu](images/SyncfusionMenu.png)

--- a/Extension/Blazor-Extension/Visual-Studio-Code/code-snippet.md
+++ b/Extension/Blazor-Extension/Visual-Studio-Code/code-snippet.md
@@ -1,65 +1,65 @@
 ---
 layout: post
 title: Code Snippet | Blazor | Syncfusion
-description: Code snippet adding a Syncfusion Blazor component with various features in the Razor code editor file of the Blazor Application.
+description: Code snippet adding a Syncfusion  Blazor component with various features in the Razor code editor file of the Blazor Application.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Add Syncfusion Blazor component in the Blazor application
+# Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component in the Blazor application
 
-The Syncfusion Blazor code snippet utility for Visual Studio Code includes snippets for inserting a Syncfusion Blazor component with various features into the Blazor Application's Razor code editor.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor code snippet utility for Visual Studio Code includes snippets for inserting a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component with various features into the Blazor Application's Razor code editor.
 
-   > The Syncfusion Blazor code snippet is available from Essential Studio 2021 Volume 1 (`v19.1.0.54`).
+   > The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor code snippet is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  2021 Volume 1 (`v19.1.0.54`).
 
-## Add a Syncfusion Blazor component
+## Add a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component
 
-The instructions below guide you the process of using the Syncfusion Blazor code snippet in your Blazor application.
+The instructions below guide you the process of using the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor code snippet in your Blazor application.
 
 1. In Visual Studio Code, open an existing Blazor Application or create a new Blazor Application.
 
-2. Open the razor file that you need and place the cursor in required place where you want to add Syncfusion component.
+2. Open the razor file that you need and place the cursor in required place where you want to add Syncfusion<sup style="font-size:70%">&reg;</sup>  component.
 
-3. You can find the Syncfusion Blazor component with the various features by typing the **sf** word in the format shown below.
+3. You can find the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component with the various features by typing the **sf** word in the format shown below.
 
     ```bash
     sf<Syncfusion component name>-<Syncfusion component feature>
 
     For Example, sfgrid-grouping
     ```
-4. Choose the Syncfusion component and click the **Enter** or **Tab** key, the Syncfusion Blazor component will be added in the razor file.
+4. Choose the Syncfusion<sup style="font-size:70%">&reg;</sup>  component and click the **Enter** or **Tab** key, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component will be added in the razor file.
 
     ![Code Snippet](images/codesnippet.gif)
 
-5. After adding the Syncfusion Blazor component to the razor file, use the tab key to fill in the required values to render the component with data. You can find the comment section in the code snippet to see what values are required.
+5. After adding the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component to the razor file, use the tab key to fill in the required values to render the component with data. You can find the comment section in the code snippet to see what values are required.
 
     ![Comment](images/Comment.png)
 
-6. You can also find the Syncfusion help link at the top of the added snippet to learn more about the new Syncfusion Blazor component feature.
+6. You can also find the Syncfusion<sup style="font-size:70%">&reg;</sup>  help link at the top of the added snippet to learn more about the new Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component feature.
 
     ![Help](images/Help.png)
 
 ## Configure Blazor application with Syncfusion
 
-The Syncfusion Blazor snippet simply inserts the code into the razor file. You must configure the Blazor application with Syncfusion by installing the Syncfusion Blazor NuGet package, namespace, themes, and registering the Syncfusion Blazor Service. To configure, follow the steps below:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor snippet simply inserts the code into the razor file. You must configure the Blazor application with Syncfusion<sup style="font-size:70%">&reg;</sup>  by installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet package, namespace, themes, and registering the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Service. To configure, follow the steps below:
 
-1. Open the Blazor application file and manually add the required Syncfusion Blazor individual NuGet package(s) for the Syncfusion Blazor components as a package reference. Refer to [this section](https://blazor.syncfusion.com/documentation/nuget-packages/#benefits-of-using-individual-nuget-packages) to learn about the advantages of the individual NuGet packages. This NuGet package will be automatically restored when building the application.
+1. Open the Blazor application file and manually add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor individual NuGet package(s) for the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor components as a package reference. Refer to [this section](https://blazor.syncfusion.com/documentation/nuget-packages/#benefits-of-using-individual-nuget-packages) to learn about the advantages of the individual NuGet packages. This NuGet package will be automatically restored when building the application.
 
     ![NuGet Package](images/NuGet-Snippet.png)
 
-    > Starting with Volume 4, 2020 (v18.4.0.30) release, Syncfusion provides [individual NuGet packages](https://blazor.syncfusion.com/documentation/nuget-packages/) for our Syncfusion Blazor components. We highly recommend this new standard for your Blazor production applications.
+    > Starting with Volume 4, 2020 (v18.4.0.30) release, Syncfusion<sup style="font-size:70%">&reg;</sup>  provides [individual NuGet packages](https://blazor.syncfusion.com/documentation/nuget-packages/) for our Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor components. We highly recommend this new standard for your Blazor production applications.
 
-2. To render the Syncfusion components in your application, open the **~/_Imports.razor** file and add the required Syncfusion Blazor namespace entries.
+2. To render the Syncfusion<sup style="font-size:70%">&reg;</sup>  components in your application, open the **~/_Imports.razor** file and add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor namespace entries.
 
     ![Namespace](images/Namespace-Snippet.png)
 
-3. Add the Syncfusion Blazor [theme](https://blazor.syncfusion.com/documentation/appearance/themes/) in the `<head>` element of the **~/Pages/_Host.html** page for server application and **~/wwwroot/index.html** page for a client application.
+3. Add the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor [theme](https://blazor.syncfusion.com/documentation/appearance/themes/) in the `<head>` element of the **~/Pages/_Host.html** page for server application and **~/wwwroot/index.html** page for a client application.
 
     ![Themes](images/Themes-Snippet.png)
 
-4. Open the **~/Startup.cs** file for server application and the **~/Program.cs** file for client application then register the Syncfusion Blazor Service.
+4. Open the **~/Startup.cs** file for server application and the **~/Program.cs** file for client application then register the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Service.
 
     ![Syncfusion Configuration](images/Configuration-Snippet.png)
 
-5. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+5. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.

--- a/Extension/Blazor-Extension/Visual-Studio-Code/convert-project.md
+++ b/Extension/Blazor-Extension/Visual-Studio-Code/convert-project.md
@@ -1,23 +1,23 @@
 ---
 layout: post
 title: Project Conversion | Blazor | Syncfusion
-description: Project Conversion is a add-in that converts Blazor application into a Syncfusion Blazor application by adding required Syncfusion components
+description: Project Conversion is a add-in that converts Blazor application into a Syncfusion  Blazor application by adding required Syncfusion  components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Blazor Conversion
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Conversion
 
-The Syncfusion Blazor conversion is an add-in for Visual Studio Code that converts an existing Blazor application into a Syncfusion Blazor Web Application by adding the required NuGet packages and themes.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor conversion is an add-in for Visual Studio Code that converts an existing Blazor application into a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application by adding the required NuGet packages and themes.
 
-   > The Syncfusion Blazor Web Application Project Conversion utility is available from `v17.4.0.39`.
+   > The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application Project Conversion utility is available from `v17.4.0.39`.
 
-The steps below assist you to using the Syncfusion Project conversion in your existing Blazor Web Application:
+The steps below assist you to using the Syncfusion<sup style="font-size:70%">&reg;</sup>  Project conversion in your existing Blazor Web Application:
 
 1. Open an existing Blazor Web Application or create a new Microsoft Blazor Web Application in Visual Studio Code.
 
-2. Select **Convert to Syncfusion Blazor Application...** from the context menu when you right-click on the **Project file** from Explorer (Workspace). Refer the screenshot below.
+2. Select **Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Application...** from the context menu when you right-click on the **Project file** from Explorer (Workspace). Refer the screenshot below.
 
     ![Conversion Add-in](images/Conversion.PNG)
 
@@ -29,19 +29,19 @@ The steps below assist you to using the Syncfusion Project conversion in your ex
 
     ![Select Themes](images/ChooseThemes.PNG)
 
-5. The application configured with Syncfusion Blazor required NuGet packages and themes.
+5. The application configured with Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor required NuGet packages and themes.
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
 ## NuGet Packages
 
 Based on the application type, the following NuGet packages are added as NuGet references.
 
-| Syncfusion Blazor NuGet packages  | Application type  |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages  | Application type  |
 |---|---|
-| `Syncfusion.Blazor`  | Syncfusion Blazor Server App <br/> Syncfusion Blazor WebAssembly App <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application)|
-| `Syncfusion.Blazor.PdfViewerServer.Windows`  | Syncfusion Blazor Server App  |
-| `Syncfusion.Blazor.WordProcessor`  | Syncfusion Blazor Server App <br/> Syncfusion Blazor WebAssembly App <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application)|
+| `Syncfusion.Blazor`  | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application)|
+| `Syncfusion.Blazor.PdfViewerServer.Windows`  | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App  |
+| `Syncfusion.Blazor.WordProcessor`  | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application)|
 
 The NuGet packages added to the application file as follows.
 
@@ -49,12 +49,12 @@ The NuGet packages added to the application file as follows.
 
 ## Theme links
 
-While converting the application, the selected Syncfusion Blazor theme is added in the following location of a Blazor type application.
+While converting the application, the selected Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor theme is added in the following location of a Blazor type application.
 
 | Application type  | File location  |
 |---|---|
-| Syncfusion Blazor Server App | {Project location}\Pages\\_Host.cshtml |
-| Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application)| {Client Project location}\wwwroot\index.html  |
-| Syncfusion Blazor WebAssembly App  | {Project location}\wwwroot\index.html|
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App | {Project location}\Pages\\_Host.cshtml |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application)| {Client Project location}\wwwroot\index.html  |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App  | {Project location}\wwwroot\index.html|
 
 ![CDNLink](images/CDNLink.png)

--- a/Extension/Blazor-Extension/Visual-Studio-Code/create-project.md
+++ b/Extension/Blazor-Extension/Visual-Studio-Code/create-project.md
@@ -1,37 +1,37 @@
 ---
 layout: post
 title: Project Templates | Blazor | Syncfusion
-description: Syncfusion provides Visual Studio Code Project Templates for Blazor platform to create the Syncfusion Blazor Application using Syncfusion components
+description: Syncfusion  provides Visual Studio Code Project Templates for Blazor platform to create the Syncfusion  Blazor Application using Syncfusion components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Create Project with Syncfusion Blazor Template Studio
+# Create Project with Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio
 
-Syncfusion provides **Visual Studio Code project templates** for creating Syncfusion Blazor application. Syncfusion Blazor generates application that include the necessary Syncfusion NuGet packages, namespaces, and component render code for the Calendar, Button, and DataGrid components, as well as the style for making Syncfusion component development easier.
+Syncfusion provides **Visual Studio Code project templates** for creating Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application. Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor generates application that include the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, namespaces, and component render code for the Calendar, Button, and DataGrid components, as well as the style for making Syncfusion<sup style="font-size:70%">&reg;</sup>  component development easier.
 
-> Blazor project templates from `v17.4.0.39` are supported by the Syncfusion Visual Studio Code project template.
+> Blazor project templates from `v17.4.0.39` are supported by the Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Code project template.
 
 The instructions below assist you in creating **Syncfusion Blazor Applications** using **Visual Studio Code**:
 
-1. To create a Syncfusion Blazor application in Visual Studio Code, open the command palette by pressing **Ctrl+Shift+P**. Search for the word **Syncfusion** in the Visual Studio Code palette to get the templates provided by Syncfusion.
+1. To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application in Visual Studio Code, open the command palette by pressing **Ctrl+Shift+P**. Search for the word **Syncfusion** in the Visual Studio Code palette to get the templates provided by Syncfusion.
 
     ![CreateProjectPalette](images/CreateBlazorProjectPalette.png)
 
-2. Select **Syncfusion Blazor Template Studio: Launch**, then press **Enter** key. The Template Studio wizard for configuring the Syncfusion Blazor app will be launched. Provide the Project Name and Project Path.
+2. Select **Syncfusion Blazor Template Studio: Launch**, then press **Enter** key. The Template Studio wizard for configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor app will be launched. Provide the Project Name and Project Path.
 
     ![TemplateStudioWizard](images/ProjectLocationName.png)
 
-N> Refer to the .NET SDK support for Syncfusion Blazor Components [here](https://blazor.syncfusion.com/documentation/system-requirements#net-sdk).
+N> Refer to the .NET SDK support for Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Components [here](https://blazor.syncfusion.com/documentation/system-requirements#net-sdk).
 
-3. Select either **Next** or the **Project Type** tab. Syncfusion Blazor project types will be displayed. Choose one of the following Syncfusion Blazor project types based on the version of the .NET SDK you are using.
+3. Select either **Next** or the **Project Type** tab. Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor project types will be displayed. Choose one of the following Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor project types based on the version of the .NET SDK you are using.
 
-    | .NET SDK version | Supported Syncfusion Blazor Application Type |
+    | .NET SDK version | Supported Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Application Type |
     | ------------- | ------------- |
-    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) | Syncfusion Blazor Web App |
-    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0), [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion Blazor WebAssembly App |
-    | [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion Blazor Server App |
+    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web App |
+    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0), [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App |
+    | [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App |
 
     In the **Syncfusion Blazor Web App** application type, you can configure the following options:
 
@@ -68,17 +68,17 @@ N> Refer to the .NET SDK support for Syncfusion Blazor Components [here](https:/
 
     > ASP.NET Core hosted and Progressive Web Application options are only visible if Blazor Web Assembly App project type is selected.
 
-5. Click the **Create** button. The Syncfusion Blazor application has been created. The created Syncfusion Blazor app has the Syncfusion NuGet packages, styles, and the component render code for the Syncfusion component added to the Index, Counter, and FetchData pages.
+5. Click the **Create** button. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application has been created. The created Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor app has the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, styles, and the component render code for the Syncfusion<sup style="font-size:70%">&reg;</sup>  component added to the Index, Counter, and FetchData pages.
 
-6. You can run the application to see the Syncfusion components. Click **F5** or go to **Run>Start Debugging**.
+6. You can run the application to see the Syncfusion<sup style="font-size:70%">&reg;</sup>  components. Click **F5** or go to **Run>Start Debugging**.
 
     ![Debug](images/Debug.png)
 
-7. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+7. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
-## Syncfusion integration
+## Syncfusion<sup style="font-size:70%">&reg;</sup>  integration
 
-The Syncfusion Blazor application configures with latest Syncfusion Blazor NuGet packages, styles, namespaces, and component render code for Syncfusion components are added in the created application.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application configures with latest Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages, styles, namespaces, and component render code for Syncfusion<sup style="font-size:70%">&reg;</sup>  components are added in the created application.
 
 ### NuGet Packages
 
@@ -88,25 +88,25 @@ The `Syncfusion.Blazor` NuGet package will be added as NuGet references for all 
 
 ### Style
 
-The selected theme is added from Syncfusion NuGet and its reference at these applications locations in Blazor.
+The selected theme is added from Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet and its reference at these applications locations in Blazor.
 
 | Application type  | File location  |
 |---|---|
-| Syncfusion Blazor Server App | {Project location}\Pages\\_Host.cshtml |
-| Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
-| Syncfusion Blazor WebAssembly App  | {Project location}\wwwroot\index.html|
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App | {Project location}\Pages\\_Host.cshtml |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App  | {Project location}\wwwroot\index.html|
 
 ![CDNLink](images/CDNLink.png)
 
 ### Namespaces
 
-The Syncfusion Blazor namespaces are added in the **`_imports.razor`** file.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor namespaces are added in the **`_imports.razor`** file.
 
 ![NameSpace](images/NameSpace.png)
 
 ### Component render code
 
-The Syncfusion Blazor Calendar, Button, and DataGrid component render code is in the Razor files in the pages folder. The render code is updated in these Razor files.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Calendar, Button, and DataGrid component render code is in the Razor files in the pages folder. The render code is updated in these Razor files.
 
 | File name  | Code snippet added |
 |---|---|

--- a/Extension/Blazor-Extension/Visual-Studio-Code/download-and-installation.md
+++ b/Extension/Blazor-Extension/Visual-Studio-Code/download-and-installation.md
@@ -1,19 +1,19 @@
 ---
 layout: post
 title: Download and Installation | Blazor | Syncfusion
-description: How to download and install the Syncfusion Blazor Visual Studio Extensions from Visual Studio Market Place
+description: How to download and install the Syncfusion  Blazor Visual Studio Extensions from Visual Studio Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Download and Installation
 
-Syncfusion publishes the Visual Studio Code extension in the [Visual Studio Code marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Blazor-VSCode-Extensions). You can either install it directly from Visual Studio Code or download and install it from the Visual Studio Code marketplace.
+Syncfusion<sup style="font-size:70%">&reg;</sup> publishes the Visual Studio Code extension in the [Visual Studio Code marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Blazor-VSCode-Extensions). You can either install it directly from Visual Studio Code or download and install it from the Visual Studio Code marketplace.
 
 ## Prerequisites
 
-The following software prerequisites must be installed to install the Syncfusion Blazor extension, as well as to creating, adding component code, converting, and upgrading Syncfusion Blazor applications.
+The following software prerequisites must be installed to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extension, as well as to creating, adding component code, converting, and upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor applications.
 
 * [Visual Studio Code 1.29.0 or later](https://code.visualstudio.com/download)
 
@@ -25,13 +25,13 @@ The following software prerequisites must be installed to install the Syncfusion
 
 ## Install through the Visual Studio Code Extensions
 
-The instructions below describe the process of installing the Syncfusion Blazor extensions from Visual Studio Code Extensions.
+The instructions below describe the process of installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extensions from Visual Studio Code Extensions.
 
 1. Open Visual Studio Code.
 
 2. Navigate to **View > Extensions**, and the Manage Extensions option will appear on the left side of the window.
 
-3. By entering the keyword **"Syncfusion Blazor"** in the search box, you can find the Syncfusion Blazor Visual Studio Code extension in the Visual Studio Code Marketplace.
+3. By entering the keyword **"Syncfusion Blazor"** in the search box, you can find the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Visual Studio Code extension in the Visual Studio Code Marketplace.
 
      ![Extension](images/Extension.png)
 
@@ -41,13 +41,13 @@ The instructions below describe the process of installing the Syncfusion Blazor 
 
      ![Reload-Window](images/Reload-Window.png)
 
-6. Now, you can create a new Syncfusion Blazor application by using the Syncfusion Blazor extensions from the Visual Studio Code Palette Find the **Syncfusion Blazor Template Studio: Launch** from Visual Studio Code commands to open the Syncfusion Blazor Template Studio wizard.
+6. Now, you can create a new Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application by using the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extensions from the Visual Studio Code Palette Find the **Syncfusion Blazor Template Studio: Launch** from Visual Studio Code commands to open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio wizard.
 
      ![CreateProjectPalette](images/CreateProjectPalette.png)
 
 ## Install from the Visual Studio Code Marketplace
 
-The instructions below describe the process of downloading and installing Syncfusion Blazor applications from the Visual Studio Code Marketplace.
+The instructions below describe the process of downloading and installing Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor applications from the Visual Studio Code Marketplace.
 
 1. Open [Syncfusion Blazor Code Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Blazor-VSCode-Extensions) in Visual Studio Code Marketplace.
 
@@ -59,6 +59,6 @@ The instructions below describe the process of downloading and installing Syncfu
 
      ![Reload-Window](images/Reload-Window.png)
 
-5. Now, you can create a new Syncfusion Blazor application by using the Syncfusion Blazor extensions from the Visual Studio Code Palette Find the **Syncfusion Blazor Template Studio: Launch** from Visual Studio Code commands to open the Syncfusion Blazor Template Studio wizard.
+5. Now, you can create a new Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application by using the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extensions from the Visual Studio Code Palette Find the **Syncfusion Blazor Template Studio: Launch** from Visual Studio Code commands to open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio wizard.
 
      ![CreateProjectPalette](images/CreateProjectPalette.png)

--- a/Extension/Blazor-Extension/Visual-Studio-Code/overview.md
+++ b/Extension/Blazor-Extension/Visual-Studio-Code/overview.md
@@ -1,22 +1,22 @@
 ---
 layout: post
 title: Blazor VSCode Extension | Extension | Syncfusion
-description: An Extension provides you with quick access so that you can create or configure the Syncfusion Blazor projects along with Syncfusion components
+description: An Extension provides you with quick access so that you can create or configure the Syncfusion  Blazor projects along with Syncfusion  components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Blazor Extension for Visual Studio Code
 
-The Syncfusion Essential Studio Blazor extension for Visual Studio Code simplifies the use of the Syncfusion Blazor components by configuring the Syncfusion Blazor NuGet packages and themes.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  Blazor extension for Visual Studio Code simplifies the use of the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor components by configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages and themes.
 
-The Syncfusion Blazor provides the following support in Visual Studio Code:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor provides the following support in Visual Studio Code:
 
-[Project-Template](./create-project):  Creates Syncfusion Blazor applications with required configuration for development with Syncfusion Blazor component.
+[Project-Template](./create-project):  Creates Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor applications with required configuration for development with Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component.
 
-[Code Snippet](./code-snippet):  Adds a Syncfusion Blazor component with various features to the Blazor Application's Razor code editor.
+[Code Snippet](./code-snippet):  Adds a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component with various features to the Blazor Application's Razor code editor.
 
-[Convert project](./convert-project):  Converts an existing Blazor Web Application to a Syncfusion Blazor Web Application by importing the necessary Syncfusion NuGet packages.
+[Convert project](./convert-project):  Converts an existing Blazor Web Application to a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application by importing the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages.
 
-[Upgrade project](./upgrade-project):  Upgrades the existing Syncfusion Blazor Web Application from one Essential Studio version to another version.
+[Upgrade project](./upgrade-project):  Upgrades the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.

--- a/Extension/Blazor-Extension/Visual-Studio-Code/upgrade-project.md
+++ b/Extension/Blazor-Extension/Visual-Studio-Code/upgrade-project.md
@@ -1,36 +1,36 @@
 ---
 layout: post
 title: Project Migration | Blazor | Syncfusion
-description: Project Migration is a add-in that helps migrate existing Syncfusion Blazor project from one Syncfusion version to another version
+description: Project Migration is a add-in that helps migrate existing Syncfusion  Blazor project from one Syncfusion  version to another version
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Upgrading Syncfusion Blazor application to latest version
+# Upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application to latest version
 
-The Syncfusion Blazor Migration is an add-in for Visual Studio Code allows you to migrate an existing Syncfusion Blazor Web Application from one Essential Studio version to another.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Migration is an add-in for Visual Studio Code allows you to migrate an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another.
 
-   > The Syncfusion Blazor Web Application Project Migration utility is available from `v17.4.0.39`.
+   > The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application Project Migration utility is available from `v17.4.0.39`.
 
-The steps below assist you to migrating existing Syncfusion Blazor Web Application.
+The steps below assist you to migrating existing Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application.
 
-1. Open an existing Syncfusion Blazor Web Application or create a new Syncfusion Blazor Web Application in Visual Studio Code.
+1. Open an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application or create a new Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application in Visual Studio Code.
 
-2. Select **Migrate Syncfusion Blazor Application to another version...** from the context menu when you right-click on the **Project file** from Explorer (Workspace). Refer to the screenshot below.
+2. Select **Migrate Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Application to another version...** from the context menu when you right-click on the **Project file** from Explorer (Workspace). Refer to the screenshot below.
 
     ![Migration add-in](images/Migration.PNG)
 
-    >  If you have a Syncfusion Blazor reference in your application, the Migration option will be enabled.
+    >  If you have a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor reference in your application, the Migration option will be enabled.
 
 3. **Select Blazor Version** (which published in `nuget.org`) from the palette appears.
 
     ![Select Blazor Version](images/VersionSelection.PNG)
 
-4. The Syncfusion NuGet packages references and themes are updated to the selected version in the application.
+4. The Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages references and themes are updated to the selected version in the application.
 
     ![NuGetPackage](images/NuGetPackage.png)
 
     ![CDNLink](images/CDNLink.png)
 
-5. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+5. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.

--- a/Extension/Blazor-Extension/Visual-Studio/Syncfusion-Notifications.md
+++ b/Extension/Blazor-Extension/Visual-Studio/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications | Blazor | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in Blazor applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in Blazor applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> Blazor**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Blazor**
 
 ![Option Page](images/blazor-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your Blazor application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your Blazor application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/blazor-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/blazor-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio Blazor,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your Blazor development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio Blazor,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your Blazor development projects.
 
 ![Build Notification](images/blazor-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your Blazor application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your Blazor application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/blazor-invalid.png)
 

--- a/Extension/Blazor-Extension/Visual-Studio/code-generator.md
+++ b/Extension/Blazor-Extension/Visual-Studio/code-generator.md
@@ -1,24 +1,24 @@
 ---
 layout: post
 title: Code Generator | Blazor | Syncfusion
-description: Syncfusion provides the Code Genearator for Blazor platform to add a Syncfusion Blazor component code in the Blazor application
+description: Syncfusion  provides the Code Genearator for Blazor platform to add a Syncfusion  Blazor component code in the Blazor application
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
 ---
 
-# Add Syncfusion Blazor component code
+# Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component code
 
 
-Syncfusion provides the component Code Generator for the Blazor platform, which allows you to quickly add component code to the application at the required place in the razor file. The Syncfusion extension adds the required Syncfusion component to render the code with namespaces, styles, and NuGet references. The Code Generator is a simple wizard that interacts with data models and adds Syncfusion components with the required features to your application.
+Syncfusion provides the component Code Generator for the Blazor platform, which allows you to quickly add component code to the application at the required place in the razor file. The Syncfusion<sup style="font-size:70%">&reg;</sup>  extension adds the required Syncfusion<sup style="font-size:70%">&reg;</sup>  component to render the code with namespaces, styles, and NuGet references. The Code Generator is a simple wizard that interacts with data models and adds Syncfusion<sup style="font-size:70%">&reg;</sup>  components with the required features to your application.
 
-The steps below will assist you to add the Syncfusion components code in your Blazor application through **Visual Studio 2019**:
+The steps below will assist you to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  components code in your Blazor application through **Visual Studio 2019**:
 
-> Before using the Syncfusion Blazor Code Generator, check whether the Syncfusion Blazor Extension is installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
+> Before using the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Code Generator, check whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Extension is installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
 
 1. Open your existing Blazor application or create a new Blazor application.
 
-2. To open the Syncfusion Blazor Code Generator Wizard, select one of the options below in the Razor file, and then add Syncfusion components:
+2. To open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Code Generator Wizard, select one of the options below in the Razor file, and then add Syncfusion<sup style="font-size:70%">&reg;</sup>  components:
 
     **Option 1:**
 
@@ -28,11 +28,11 @@ The steps below will assist you to add the Syncfusion components code in your Bl
 
     **Option 2:**
 
-    Open the .razor file and choose **Extension -> Syncfusion -> Essential Studio for Blazor -> Syncfusion Blazor Code Generator...** from the **Visual Studio 2019 menu**.
+    Open the .razor file and choose **Extension -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Essential Studio<sup style="font-size:70%">&reg;</sup>  for Blazor -> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Code Generator...** from the **Visual Studio 2019 menu**.
 
     ![CodeGeneratorMenu](images/Code-Generator-Menu.PNG)
 
-3. The wizard for the Syncfusion Blazor Code Generator will appear. Choose a required control.
+3. The wizard for the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Code Generator will appear. Choose a required control.
 
     ![CodeGeneratorWizard](images/Code-Generator-MainWizard.png)
 
@@ -50,29 +50,29 @@ The steps below will assist you to add the Syncfusion components code in your Bl
 
     ![OutputWindow](images/Code-Generator-OutputWindow.PNG)
 
-5. If you have installed the trial setup or NuGet packages from nuget.org, you must register the Syncfusion license key to your application as Syncfusion has introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post to know more about the licensing changes introduced in Essential Studio.
+5. If you have installed the trial setup or NuGet packages from nuget.org, you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application as Syncfusion<sup style="font-size:70%">&reg;</sup>  has introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post to know more about the licensing changes introduced in Essential Studio.
 
-## Syncfusion integration
+## Syncfusion<sup style="font-size:70%">&reg;</sup>  integration
 
-The created Syncfusion Blazor application have the most recent Syncfusion Blazor NuGet packages, styles, namespaces, and component render code for Syncfusion components.
+The created Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application have the most recent Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages, styles, namespaces, and component render code for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ### NuGet Packages
 
-Based on the selected Syncfusion Blazor controls, the individual NuGet packages can be added as NuGet references. Refer [this topic](https://blazor.syncfusion.com/staging/documentation/nuget-packages/) to know about the individual Blazor NuGet packages.
+Based on the selected Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor controls, the individual NuGet packages can be added as NuGet references. Refer [this topic](https://blazor.syncfusion.com/staging/documentation/nuget-packages/) to know about the individual Blazor NuGet packages.
 
-> The latest Syncfusion Essential Studio version of a NuGet package will be added as reference entry from nuget.org if there is no internet connection. You should restore the NuGet packages when internet becomes available.
+> The latest Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  version of a NuGet package will be added as reference entry from nuget.org if there is no internet connection. You should restore the NuGet packages when internet becomes available.
 
 ![NuGetPackage](images/Code-Generator-NuGetPackage.PNG)
 
 ### Style
 
-The selected Syncfusion Blazor theme is added from Syncfusion NuGet and this theme reference will be added at these applications locations in Blazor.
+The selected Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor theme is added from Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet and this theme reference will be added at these applications locations in Blazor.
 
 | Application type  | File location  |
 |---|---|
-| Syncfusion Blazor Server App | {Project location}\Pages\\_Host.cshtml |
-| Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
-| Syncfusion Blazor WebAssembly App <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application) | {Project location}\wwwroot\index.html|
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App | {Project location}\Pages\\_Host.cshtml |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application) | {Project location}\wwwroot\index.html|
 
 ![StyleReference](images/Code-Generator-CDNLink.PNG)
 

--- a/Extension/Blazor-Extension/Visual-Studio/convert-project.md
+++ b/Extension/Blazor-Extension/Visual-Studio/convert-project.md
@@ -1,41 +1,41 @@
 ---
 layout: post
 title: Project Conversion | Blazor | Syncfusion
-description: Project Conversion is a add-in that converts Blazor application into a Syncfusion Blazor application by adding required Syncfusion components
+description: Project Conversion is a add-in that converts Blazor application into a Syncfusion  Blazor application by adding required Syncfusion  components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Converting Blazor application to Syncfusion Blazor application
+# Converting Blazor application to Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application
 
-Syncfusion Blazor conversion is a Visual Studio add-in that converts an existing Blazor application to the Syncfusion Blazor application by adding the required assemblies and theme files.
+Syncfusion Blazor conversion is a Visual Studio add-in that converts an existing Blazor application to the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application by adding the required assemblies and theme files.
 
 The steps below help you to convert the **Blazor application** to the **Syncfusion Blazor application** via the **Visual Studio 2019**:
 
-> Before use the Syncfusion Blazor Project Conversion, check whether the Syncfusion Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Project Conversion, check whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
 
 1. Open your existing Blazor application or create a new Blazor application
 
-2. To open the Syncfusion Project Conversion Wizard, follow either one of the options below:
+2. To open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Conversion Wizard, follow either one of the options below:
 
     **Option 1:**
 
-    Choose **Extensions -> Syncfusion -> Essential Studio for Blazor -> Convert Project...** in the Visual Studio 2019 menu.
+    Choose **Extensions -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Essential Studio<sup style="font-size:70%">&reg;</sup>  for Blazor -> Convert Project...** in the Visual Studio 2019 menu.
 
     ![ConversionMenu](images/ConversionMenu.png)
 
     **Option 2:**
 
-    Right-click the application from the **Solution Explorer** and select the **Syncfusion Blazor** and choose the **Convert to Syncfusion Blazor application...**
+    Right-click the application from the **Solution Explorer** and select the **Syncfusion Blazor** and choose the **Convert to Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application...**
 
     ![ConversionAddin](images/ConversionAddin.png)
 
-3. The Syncfusion Blazor Project Conversion window will appear. You can choose the required version of Syncfusion Blazor and Themes to convert the application.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Project Conversion window will appear. You can choose the required version of Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor and Themes to convert the application.
 
     ![ConversionWizard](images/Conversion.png)
 
-    > The versions are loaded from the Syncfusion Blazor NuGet packages published in [`NuGet.org`](https://www.nuget.org/packages?q=Tags%3A%22blazor%22syncfusion) and it requires internet connectivity.
+    > The versions are loaded from the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages published in [`NuGet.org`](https://www.nuget.org/packages?q=Tags%3A%22blazor%22syncfusion) and it requires internet connectivity.
 
 4. Check the **“Enable a backup before converting”** checkbox if you want to take the project backup and choose the location.
 
@@ -47,17 +47,17 @@ The steps below help you to convert the **Blazor application** to the **Syncfusi
 
     ![ConversionBackupLocation](images/Backuplocation.png)
 
-6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
 ## NuGet Packages
 
 Based on the application type, the following NuGet packages are added as NuGet references.
 
-| Syncfusion Blazor NuGet packages  | Application type  |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages  | Application type  |
 |---|---|
-| `Syncfusion.Blazor`  | Syncfusion Blazor Server App <br/> Syncfusion Blazor WebAssembly App <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application) <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application)|
-| `Syncfusion.Blazor.PdfViewerServer.Windows`  | Syncfusion Blazor Server App  |
-| `Syncfusion.Blazor.WordProcessor`  | Syncfusion Blazor Server App <br/> Syncfusion Blazor WebAssembly App <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application) <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application)|
+| `Syncfusion.Blazor`  | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application)|
+| `Syncfusion.Blazor.PdfViewerServer.Windows`  | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App  |
+| `Syncfusion.Blazor.WordProcessor`  | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application)|
 
 The NuGet packages added to the application file as follows.
 
@@ -65,12 +65,12 @@ The NuGet packages added to the application file as follows.
 
 ## Theme link
 
-While converting the application, the Syncfusion Blazor theme is added in the following location of a Blazor application.
+While converting the application, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor theme is added in the following location of a Blazor application.
 
 | Application type  | File location  |
 |---|---|
-| Syncfusion Blazor Server App | {Project location}\Pages\\_Host.cshtml |
-| Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
-| Syncfusion Blazor WebAssembly App <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application) | {Project location}\wwwroot\index.html|
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App | {Project location}\Pages\\_Host.cshtml |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application) | {Project location}\wwwroot\index.html|
 
 ![CDNLink](images/CDNLink.png)

--- a/Extension/Blazor-Extension/Visual-Studio/download-and-installation.md
+++ b/Extension/Blazor-Extension/Visual-Studio/download-and-installation.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: Download and Installation | Blazor | Syncfusion
-description: How to download and install the Syncfusion Blazor Visual Studio Extensions from Visual Studio Market Place
+description: How to download and install the Syncfusion  Blazor Visual Studio Extensions from Visual Studio Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -13,7 +13,7 @@ Syncfusion publishes the Visual Studio extension in the [Visual Studio marketpla
 
 ## Prerequisites
 
-The following software prerequisites must be installed to install the Syncfusion Blazor extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion Blazor applications.
+The following software prerequisites must be installed to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor applications.
 
 * [Visual Studio 2019 16.3 or later](https://visualstudio.microsoft.com/downloads).
 
@@ -21,7 +21,7 @@ The following software prerequisites must be installed to install the Syncfusion
 
 ## Install through the Visual Studio Manage Extensions
 
-The steps below assist you to how to install the Syncfusion Blazor extensions from **Visual Studio Manage Extensions**.
+The steps below assist you to how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extensions from **Visual Studio Manage Extensions**.
 
 1. Open the Visual Studio 2019.
 
@@ -41,13 +41,13 @@ The steps below assist you to how to install the Syncfusion Blazor extensions fr
 
 7. After the installation is complete, open Visual Studio 2019.
 
-8. Now, under the menu **Extensions**, you can use the Syncfusion extensions from the Visual Studio.
+8. Now, under the menu **Extensions**, you can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio.
 
     ![SyncfusionMenu](images/SyncfusionMenu.png)
 
 ## Install from the Visual Studio Marketplace
 
-The steps below illustrate how to download and install the Syncfusion Blazor extension from the Visual Studio Marketplace.
+The steps below illustrate how to download and install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extension from the Visual Studio Marketplace.
 
 1. Download the [Syncfusion Blazor Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Blazor-Extension) from the Visual Studio Marketplace.
 
@@ -59,6 +59,6 @@ The steps below illustrate how to download and install the Syncfusion Blazor ext
 
 4. Click the **Modify** button.
 
-5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion extensions from the Visual Studio under the **Extensions** menu.
+5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio under the **Extensions** menu.
 
      ![SyncfusionMenu](images/SyncfusionMenu.png)

--- a/Extension/Blazor-Extension/Visual-Studio/overview.md
+++ b/Extension/Blazor-Extension/Visual-Studio/overview.md
@@ -1,22 +1,22 @@
 ---
 layout: post
 title: Blazor Extension | Extension | Syncfusion
-description: An Extension provides you with quick access so that you can create or configure the Syncfusion Blazor projects along with Syncfusion components
+description: An Extension provides you with quick access so that you can create or configure the Syncfusion Blazor projects along with Syncfusion  components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Blazor Extension for Visual Studio
 
-The Syncfusion Essential Studio Blazor extension for Visual Studio simplifies the use of the Syncfusion Blazor components by configuring the Syncfusion Blazor NuGet packages and themes.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  Blazor extension for Visual Studio simplifies the use of the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor components by configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages and themes.
 
-The Syncfusion Blazor extensions provides the following add-ins in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor extensions provides the following add-ins in Visual Studio:
 
-[Project-Template](./template-studio):  Creates Syncfusion Blazor applications with required configuration for development with Syncfusion Blazor component.
+[Project-Template](./template-studio):  Creates Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor applications with required configuration for development with Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component.
 
-[Code Generator](./code-generator):  Adds Syncfusion Blazor component code in razor file at required place.
+[Code Generator](./code-generator):  Adds Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor component code in razor file at required place.
 
-[Convert project](./convert-project):  Converts an existing Blazor Web Application to a Syncfusion Blazor Web Application by importing the necessary Syncfusion NuGet packages.
+[Convert project](./convert-project):  Converts an existing Blazor Web Application to a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application by importing the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages.
 
-[Upgrade project](./upgrade-project):  Upgrades the existing Syncfusion Blazor Web Application from one Essential Studio version to another version.
+[Upgrade project](./upgrade-project):  Upgrades the existing Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web Application from one Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version.

--- a/Extension/Blazor-Extension/Visual-Studio/scaffolding.md
+++ b/Extension/Blazor-Extension/Visual-Studio/scaffolding.md
@@ -1,27 +1,27 @@
 ---
 layout: post
 title: Scaffolding | Blazor | Syncfusion
-description: Learn here about scaffolding using Syncfusion Blazor Extension for Visual Studio to quickly add code to reduce the amount of development time.
+description: Learn here about scaffolding using Syncfusion  Blazor Extension for Visual Studio to quickly add code to reduce the amount of development time.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Blazor Scaffolding
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Scaffolding
 
-Syncfusion provides **Visual Studio Scaffolding** for the Syncfusion Blazor platform, that allowing you to quickly add code that interacts with data models and reduce the time it takes to develop with data operations in your application. Scaffolding simplifies the creation of Razor and Controller action methods for Syncfusion Blazor DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, and Document Editor, and PDF Viewer controls.
+Syncfusion provides **Visual Studio Scaffolding** for the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor platform, that allowing you to quickly add code that interacts with data models and reduce the time it takes to develop with data operations in your application. Scaffolding simplifies the creation of Razor and Controller action methods for Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, and Document Editor, and PDF Viewer controls.
 
 > **Note:** Check that at least one Entity Framework model exists, and the application has been compiled once. If no Entity Framework model exists in your application, refer to this [documentation](https://www.freecodecamp.org/news/how-to-create-an-application-using-blazor-and-entity-framework-core-1c1679d87c7e/) to generate the Entity Framework model. After the model file has been added, check that the required DBContext and properties are added. Now, build the application, and try scaffolding. If any changes made in the model properties, rebuild the application once before perform scaffolding.
 
 <!-- markdownlint-disable MD026 -->
 
-> **Note:** The Syncfusion Blazor Scaffolder is available from `v17.4.0.39` for Blazor server-side application and provided the Scaffolding support to Blazor client-side application from `v18.4.0.39`.
+> **Note:** The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Scaffolder is available from `v17.4.0.39` for Blazor server-side application and provided the Scaffolding support to Blazor client-side application from `v18.4.0.39`.
 
 ## Add a scaffolded item
 
 The steps below assist you to how to add a scaffolded item to your Blazor application.
 
-> **Note:** Before use the Syncfusion Blazor Scaffolding, check whether the Syncfusion Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
+> **Note:** Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Scaffolding, check whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
 
 1. If the application type is **Blazor ServerSide**, right-click the **Pages** folder in the Solution Explorer, click **Add**, and then select **New Scaffolded Item..**
 
@@ -33,13 +33,13 @@ The steps below assist you to how to add a scaffolded item to your Blazor applic
 
 2. In the **Add New Scaffolded item** dialog, select **Syncfusion Blazor Scaffolder** and then click **‘Add’**.
 
-    ![Choose Syncfusion Scaffolding from Visual Studio Add scaffold dialog](images/Syncfusion_scaffolder.png)
+    ![Choose Syncfusion  Scaffolding from Visual Studio Add scaffold dialog](images/Syncfusion_scaffolder.png)
 
-3. In the Syncfusion UI Scaffolder dialog, select the desired control to perform scaffolding, and then click **Next**.
+3. In the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder dialog, select the desired control to perform scaffolding, and then click **Next**.
 
     ![Choose required control](images/Control_Window.png)
 
-4. The Syncfusion UI Scaffolder dialog for the selected control will be displayed. As per the application requirements, follow these steps to set up your application.
+4. The Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder dialog for the selected control will be displayed. As per the application requirements, follow these steps to set up your application.
 
     **Select Data Source Type**
     
@@ -75,11 +75,11 @@ The steps below assist you to how to add a scaffolded item to your Blazor applic
 
     ![Choose required selected control features for the hosted project](images/Fetaure_window_hosted.png)
 
-5. In the Syncfusion UI Scaffolder, the dialog for the selected control feature will open. Choose the required features, update the necessary data fields, and then click **Add**.
+5. In the Syncfusion<sup style="font-size:70%">&reg;</sup>  UI Scaffolder, the dialog for the selected control feature will open. Choose the required features, update the necessary data fields, and then click **Add**.
 
     ![Choose required selected control features for the hosted project](images/Fetaure_window_hosted_feature.png)
 
-6. With the selected features of the Syncfusion control code snippet, the **Controller/Service** file and the corresponding **Razor** files are generated.
+6. With the selected features of the Syncfusion<sup style="font-size:70%">&reg;</sup>  control code snippet, the **Controller/Service** file and the corresponding **Razor** files are generated.
 
     If you select **Local Data**, the service file and razor file will be added to the application.
 
@@ -95,11 +95,11 @@ The steps below assist you to how to add a scaffolded item to your Blazor applic
 
 7. Then, add navigation to the created razor file based on your requirement to open on the webpage.
 
-8. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+8. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
 
-## Syncfusion Blazor Command-line Scaffolding
+## Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Command-line Scaffolding
 
-**Scaffolding command-line** for Syncfusion Blazor allows you to quickly add code that interacts with data models and reduce the amount of time it takes to develop with data operations in your application. Scaffolding simplifies the creation of view file and Controller action methods for Syncfusion Blazor DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, Document Editor, and PDF Viewer controls.
+**Scaffolding command-line** for Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor allows you to quickly add code that interacts with data models and reduce the amount of time it takes to develop with data operations in your application. Scaffolding simplifies the creation of view file and Controller action methods for Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor DataGrid, Charts, Scheduler, Diagram, Tree Grid, Rich Text Editor, Document Editor, and PDF Viewer controls.
 
 > **Note:** Verify that at least one Entity Framework model exists. If your application lacks an Entity Framework model, use this [documentation](https://www.freecodecamp.org/news/how-to-create-an-application-using-blazor-and-entity-framework-core-1c1679d87c7e/) to create one. After you've added the model file, double-check that the necessary DBContext and properties have been added. Now, build the application and experiment with scaffolding. If any changes made in the model properties, rebuild the application once before perform scaffolding.
 
@@ -159,7 +159,7 @@ The steps below will assist you to how to add a scaffolded item from command-lin
 
     ![CommandLine Scaffold](images/commandline.png)
 
-5. As we can see controller and view files generated successfully and also added the Syncfusion NuGet packages and styles which is required to render Syncfusion control.
+5. As we can see controller and view files generated successfully and also added the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages and styles which is required to render Syncfusion<sup style="font-size:70%">&reg;</sup>  control.
 
     ![Blazor added Files](images/blazorfile.png)
 
@@ -167,10 +167,10 @@ The steps below will assist you to how to add a scaffolded item from command-lin
 
 <!-- markdownlint-disable MD026 -->
 
-## How to render Syncfusion control?
+## How to render Syncfusion<sup style="font-size:70%">&reg;</sup>  control?
 
-Refer to the following UG links to render Syncfusion control after performing scaffolding:
+Refer to the following UG links to render Syncfusion<sup style="font-size:70%">&reg;</sup>  control after performing scaffolding:
 
-WebAssembly App: [Configure Blazor components using Syncfusion Blazor Component NuGet Package](https://blazor.syncfusion.com/documentation/getting-started/blazor-webassembly-visual-studio)
+WebAssembly App: [Configure Blazor components using Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Component NuGet Package](https://blazor.syncfusion.com/documentation/getting-started/blazor-webassembly-visual-studio)
 
-Blazor Server App: [Configure Blazor components using Syncfusion Blazor Component NuGet Package](https://blazor.syncfusion.com/documentation/getting-started/blazor-server-side-visual-studio)
+Blazor Server App: [Configure Blazor components using Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Component NuGet Package](https://blazor.syncfusion.com/documentation/getting-started/blazor-server-side-visual-studio)

--- a/Extension/Blazor-Extension/Visual-Studio/template-studio.md
+++ b/Extension/Blazor-Extension/Visual-Studio/template-studio.md
@@ -1,35 +1,35 @@
 ---
 layout: post
 title: Template Studio | Blazor | Syncfusion
-description: Syncfusion provides the Blazor Template Studio for Blazor platform to create the Syncfusion Blazor Application using Syncfusion components
+description: Syncfusion  provides the Blazor Template Studio for Blazor platform to create the Syncfusion  Blazor Application using Syncfusion components
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Blazor Template Studio
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio
 
-Syncfusion provides the Blazor Template Studio, which allows you to create a Syncfusion Blazor application with Syncfusion components. The Syncfusion Blazor app is created with the required component Syncfusion NuGet references, namespaces, styles, and component render code. The Template Studio provides an easy-to-use project wizard that walks you through the process of creating an application with Syncfusion components.
+Syncfusion provides the Blazor Template Studio, which allows you to create a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application with Syncfusion<sup style="font-size:70%">&reg;</sup>  components. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor app is created with the required component Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet references, namespaces, styles, and component render code. The Template Studio provides an easy-to-use project wizard that walks you through the process of creating an application with Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 The steps below will assist you to create your **Syncfusion Blazor Application** through **Visual Studio 2022**:
 
-> **Note:** The Syncfusion Blazor Extensions for Visual Studio 2019 are available on Essential Studio release "20.3.0.56" and below.
+> **Note:** The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Extensions for Visual Studio 2019 are available on Essential Studio<sup style="font-size:70%">&reg;</sup>  release "20.3.0.56" and below.
 
-> Before use the Syncfusion Blazor Project Template, check whether the Syncfusion Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Project Template, check whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
 
 1. Open Visual Studio 2022.
 
-2. To create a Syncfusion Blazor application, use either one of the following options:
+2. To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application, use either one of the following options:
 
      **Option 1**
 
-     Choose **Extension -> Syncfusion -> Essential Studio for Blazor -> Create New Syncfusion Project...** from the **Visual Studio menu**.
+     Choose **Extension -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Essential Studio<sup style="font-size:70%">&reg;</sup>  for Blazor -> Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project...** from the **Visual Studio menu**.
 
      ![CreateMenu](images/CreateMenu.png)
 
      **Option 2**
 
-     Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Syncfusion templates for Blazor can be found by filtering the application type for **Syncfusion** or by entering **Syncfusion** as a keyword in the search option.
+     Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Syncfusion<sup style="font-size:70%">&reg;</sup>  templates for Blazor can be found by filtering the application type for **Syncfusion** or by entering **Syncfusion** as a keyword in the search option.
 
      ![CreateNewWindow](images/CreateNewWindow.png)
 
@@ -37,19 +37,19 @@ The steps below will assist you to create your **Syncfusion Blazor Application**
 
      ![CreateNewWizard](images/CreateNewWizard.png)
 
-4. The Syncfusion Blazor Template Studio wizard will be launched to configure the Syncfusion Blazor app.
+4. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio wizard will be launched to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor app.
 
-     > **Note:** Refer to the .NET SDK support for Syncfusion Blazor Components [here](https://blazor.syncfusion.com/documentation/system-requirements#net-sdk).
+     > **Note:** Refer to the .NET SDK support for Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Components [here](https://blazor.syncfusion.com/documentation/system-requirements#net-sdk).
 
      **Project type section**
 
-     Choose one of the Syncfusion Blazor application types based on the version of the .NET SDK you are using.
+     Choose one of the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application types based on the version of the .NET SDK you are using.
 
-    | .NET SDK version | Supported Syncfusion Blazor Application Type |
+    | .NET SDK version | Supported Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Application Type |
     | ------------- | ------------- |
-    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) | Syncfusion Blazor Web App |
-    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0), [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion Blazor WebAssembly App |
-    | [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion Blazor Server App |
+    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web App |
+    | [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0), [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App |
+    | [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0), [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App |
 
     In the **Syncfusion Blazor Web App** application type, you can configure the following options:
 
@@ -82,7 +82,7 @@ The steps below will assist you to create your **Syncfusion Blazor Application**
 
      > **Note:** The Progressive Web Application will be enabled if .NET 6.0 version or higher is installed.
 
-5. Click either **Next** or the **Controls** tab. The Syncfusion Blazor components you can add to the application are listed.
+5. Click either **Next** or the **Controls** tab. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor components you can add to the application are listed.
 
      ![Controls Section](images/ControlsSection1.png)
 
@@ -100,13 +100,13 @@ The steps below will assist you to create your **Syncfusion Blazor Application**
 
 7. Click **Next** or the **Configuration** tab to load the Configuration section. You can choose the required (.NET 8.0, .NET 7.0, and .NET 6.0), themes, https configuration, localization option, authentication type, Blazor Web App, and Blazor Web Assembly application types.
 
-     Depending on your Syncfusion Blazor Application Type, refer to the table below for supported authentication types.
+     Depending on your Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Application Type, refer to the table below for supported authentication types.
 
-     | Syncfusion Blazor Application Type | Supported Authentication Types |
+     | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Application Type | Supported Authentication Types |
      | ------------- | ------------- |
-     | Syncfusion Blazor Web App | None and Individual Accounts |
-     | Syncfusion Blazor WebAssembly App | None, Individual Accounts and Microsoft Identity Platform |
-     | Syncfusion Blazor Server App | None, Individual Accounts, Microsoft Identity Platform, and Windows |
+     | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Web App | None and Individual Accounts |
+     | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App | None, Individual Accounts and Microsoft Identity Platform |
+     | Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App | None, Individual Accounts, Microsoft Identity Platform, and Windows |
 
      If you choose the **Blazor Web App** application type, you can customize the Interactivity type and Interactivity location options.
 
@@ -122,33 +122,33 @@ The steps below will assist you to create your **Syncfusion Blazor Application**
 
      ![ProjectDetails](images/ProjectDetails.png)
 
-8. Click **Create** button. The Syncfusion Blazor application has been created. The created Syncfusion Blazor app has the Syncfusion NuGet packages, styles, and the render code for the Syncfusion component.
+8. Click **Create** button. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application has been created. The created Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor app has the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, styles, and the render code for the Syncfusion<sup style="font-size:70%">&reg;</sup>  component.
 
      ![Readme](images/readme.png)
 
-9. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+9. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
-## Syncfusion integration
+## Syncfusion<sup style="font-size:70%">&reg;</sup>  integration
 
-The Syncfusion Blazor application configures with most recent Syncfusion Blazor NuGet packages version, styles, namespaces, and component render code for Syncfusion components.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application configures with most recent Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages version, styles, namespaces, and component render code for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ### NuGet Packages
 
-Based on the selected Syncfusion Blazor controls, the individual NuGet packages can be added as NuGet references. Refer [this topic](https://blazor.syncfusion.com/staging/documentation/nuget-packages/) to know about the individual Blazor NuGet packages.
+Based on the selected Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor controls, the individual NuGet packages can be added as NuGet references. Refer [this topic](https://blazor.syncfusion.com/staging/documentation/nuget-packages/) to know about the individual Blazor NuGet packages.
 
-> The latest Syncfusion Essential Studio version of a NuGet package will be added as reference entry from nuget.org if there is no internet connection. You should restore the NuGet packages when internet becomes available.
+> The latest Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  version of a NuGet package will be added as reference entry from nuget.org if there is no internet connection. You should restore the NuGet packages when internet becomes available.
 
 ![NuGetPackage](images/NuGetPackage.png)
 
 ### Style
 
-The selected Syncfusion Blazor theme is added from Syncfusion NuGet and this theme reference will be added at these applications locations in Blazor.
+The selected Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor theme is added from Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet and this theme reference will be added at these applications locations in Blazor.
 
 | Application type  | File location  |
 |---|---|
-| Syncfusion Blazor Server App | {Project location}\Pages\\_Host.cshtml |
-| Syncfusion Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
-| Syncfusion Blazor WebAssembly App <br/> Syncfusion Blazor WebAssembly App (Progressive Web Application) | {Project location}\wwwroot\index.html|
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Server App | {Project location}\Pages\\_Host.cshtml |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted) <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (ASPNET Core hosted and Progressive Web Application) | {Client Project location}\wwwroot\index.html  |
+| Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App <br/> Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor WebAssembly App (Progressive Web Application) | {Project location}\wwwroot\index.html|
 
 ![CDNLink](images/CDNLink.png)
 
@@ -160,7 +160,7 @@ The Syncfusion.Blazor namespaces are added in the **`_imports.razor`** file.
 
 ### Component render code
 
-The selected Syncfusion Blazor components and features render code added as .razor files in the pages folder.
+The selected Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor components and features render code added as .razor files in the pages folder.
 
 ![Selected control pagess added in project with selected features](images/ControlPages.png)
 
@@ -358,7 +358,7 @@ We need to register the created application in Google Platform API Console for I
 
 ### Run application
 
-You can run the application and see the Syncfusion components you selected. Select a component to see component output.
+You can run the application and see the Syncfusion<sup style="font-size:70%">&reg;</sup>  components you selected. Select a component to see component output.
 
 ![Blazor Template output page](images/HomePage.png)
 
@@ -366,7 +366,7 @@ You can select a culture language in combobox at top right on the output page to
 
 ![Blazor Template output page](images/Localization.png)
 
-> **Note:** Above culture combobox will be enabled in sample output if localization option is selected in configuration window from Syncfusion Blazor Template Studio wizard.
+> **Note:** Above culture combobox will be enabled in sample output if localization option is selected in configuration window from Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio wizard.
 
 ### Register and Login Application
 

--- a/Extension/Blazor-Extension/Visual-Studio/upgrade-project.md
+++ b/Extension/Blazor-Extension/Visual-Studio/upgrade-project.md
@@ -1,39 +1,39 @@
 ---
 layout: post
 title: Project Migration | Blazor | Syncfusion
-description: Project Migration is a add-in that helps migrate existing Syncfusion Blazor project from one Syncfusion version to another version
+description: Project Migration is a add-in that helps migrate existing Syncfusion  Blazor project from one Syncfusion  version to another version
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Upgrading Syncfusion Blazor application to latest version
+# Upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application to latest version
 
-The Syncfusion Blazor migration add-in for Visual Studio allows you to migrate an existing Syncfusion Blazor application from one version of Essential Studio version to another version. This reduces the amount of manual work required when migrating the Syncfusion version.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor migration add-in for Visual Studio allows you to migrate an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application from one version of Essential Studio<sup style="font-size:70%">&reg;</sup>  version to another version. This reduces the amount of manual work required when migrating the Syncfusion<sup style="font-size:70%">&reg;</sup>  version.
 
-The steps below will assist you to upgrade the Syncfusion version in the Syncfusion Blazor application via Visual Studio 2019:
+The steps below will assist you to upgrade the Syncfusion<sup style="font-size:70%">&reg;</sup>  version in the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application via Visual Studio 2019:
 
-> Before use the Syncfusion Blazor Project Migration, check whether the Syncfusion Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Project Migration, check whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://blazor.syncfusion.com/documentation/visual-studio-integration/visual-studio-extensions/download-and-installation/) help topic.
 
-1. Open the Syncfusion Blazor application that uses the Syncfusion component.
+1. Open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor application that uses the Syncfusion<sup style="font-size:70%">&reg;</sup>  component.
 
 2. To open the Migration Wizard, either one of the following options should be followed:
 
     **Option 1**
 
-    Choose **Extensions -> Syncfusion -> Essential Studio for Blazor -> Migrate Project…** from Visual Studio 2019 menu.
+    Choose **Extensions -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Essential Studio<sup style="font-size:70%">&reg;</sup>  for Blazor -> Migrate Project…** from Visual Studio 2019 menu.
 
     ![MigrationMenu](images/MigrationMenu.PNG)
 
     **Option 2**
 
-    Right-click the application from the **Solution Explorer** and select the **Syncfusion Blazor** and choose the **Migrate Syncfusion Blazor project from another version...**
+    Right-click the application from the **Solution Explorer** and select the **Syncfusion Blazor** and choose the **Migrate Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor project from another version...**
 
     ![MigrationAddin](images/MigrationAddin.png)
 
-3. The Syncfusion Project Migration window will appear. You can choose the required version of Syncfusion Blazor to migrate.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Migration window will appear. You can choose the required version of Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor to migrate.
 
-    > The versions are loaded from the Syncfusion Blazor NuGet packages published in [`NuGet.org`](https://www.nuget.org/packages?q=Tags%3A%22blazor%22syncfusion) and it requires internet connectivity.
+    > The versions are loaded from the Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages published in [`NuGet.org`](https://www.nuget.org/packages?q=Tags%3A%22blazor%22syncfusion) and it requires internet connectivity.
 
     ![MigrationWizard](images/Migration.png)
 
@@ -47,6 +47,6 @@ The steps below will assist you to upgrade the Syncfusion version in the Syncfus
 
     ![MigrationBackupLocation](images/Backuplocation.png)
 
-6. The Syncfusion Blazor NuGet packages are updated to the respective version in the application.
+6. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Blazor NuGet packages are updated to the respective version in the application.
 
-7. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+7. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.

--- a/Extension/Faq/How-to-get-rid-of-from-multiple-version-alert-message-in-Syncfusion-Xamarin-Toolbox.md
+++ b/Extension/Faq/How-to-get-rid-of-from-multiple-version-alert-message-in-Syncfusion-Xamarin-Toolbox.md
@@ -1,36 +1,36 @@
 ---
 layout: post
-title: Get rid of from multiple version alert in Syncfusion Toolbox
-description: how to get rid of from multiple version alert message when drag and drop a Syncfusion component from Syncfusion Toolbox?
+title: Get rid of from multiple version alert in Syncfusion  Toolbox
+description: how to get rid of from multiple version alert message when drag and drop a Syncfusion  component from Syncfusion Toolbox?
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
 ---
 
-# Get rid of the Multiple Version Alert Messages in Syncfusion Toolbox
+# Get rid of the Multiple Version Alert Messages in Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox
 
-When dragging and dropping a Syncfusion control from either the **Syncfusion Xamarin Toolbox or the Syncfusion .NET MAUI Toolbox** into a project containing multiple versions of NuGet packages that are already installed, two types of alert message will be displayed based on the following scenarios:
+When dragging and dropping a Syncfusion<sup style="font-size:70%">&reg;</sup>  control from either the **Syncfusion Xamarin Toolbox or the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Toolbox** into a project containing multiple versions of NuGet packages that are already installed, two types of alert message will be displayed based on the following scenarios:
 
 * Same NuGet with multiple versions installed.
 * Different NuGet with multiple versions installed.
 
 ## Same NuGet with multiple versions installed
 
-The following alert message will be displayed if multiple versions of the same Syncfusion NuGet package (e.g., Syncfusion.Xamarin.SfChart **v24.1.xx** and **v24.2.xx**(xamarin) / Syncfusion.MAUI.Buttons **v24.1.xx** and **24.2.xx**(Maui)) are already installed in your project. Recommend maintaining the same version NuGet reference.
+The following alert message will be displayed if multiple versions of the same Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package (e.g., Syncfusion.Xamarin.SfChart **v24.1.xx** and **v24.2.xx**(xamarin) / Syncfusion.MAUI.Buttons **v24.1.xx** and **24.2.xx**(Maui)) are already installed in your project. Recommend maintaining the same version NuGet reference.
 
-![Syncfusion Xamarin toolbox alert message when multiple version of the same Syncfusion Xamarin NuGet package already installed in the project](Alert-message-in-Syncfusion-Xamarin-Toolbox_images\Same-NuGet-Multiple-Version-Installed.jpg)
+![Syncfusion Xamarin toolbox alert message when multiple version of the same Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin NuGet package already installed in the project](Alert-message-in-Syncfusion-Xamarin-Toolbox_images\Same-NuGet-Multiple-Version-Installed.jpg)
 
 To resolve this, follow these steps:
-1.	Uninstall the multiple versions of the same Syncfusion NuGet package currently installed in your project. 
-2.	Now, manually reinstall a single version of the Syncfusion NuGet package (e.g., Syncfusion.Xamarin.SfChart **v24.2.xx**(xamarin)  / Syncfusion.MAUI.Buttons **v24.2.xx** (Maui)) and add the necessary control render code sample to your project.
+1.	Uninstall the multiple versions of the same Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package currently installed in your project. 
+2.	Now, manually reinstall a single version of the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package (e.g., Syncfusion.Xamarin.SfChart **v24.2.xx**(xamarin)  / Syncfusion.MAUI.Buttons **v24.2.xx** (Maui)) and add the necessary control render code sample to your project.
 
 ## Different NuGet with multiple versions installed
 
-The following alert message will be displayed when different versions of Syncfusion NuGet packages are installed in your project. Hence, you are not aware of which version of the Syncfusion NuGet package you need to install in your project.
+The following alert message will be displayed when different versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages are installed in your project. Hence, you are not aware of which version of the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package you need to install in your project.
 
-![Syncfusion Xamarin toolbox alert message when different Syncfusion Xamarin NuGet packages are installed with multiple version in the project](Alert-message-in-Syncfusion-Xamarin-Toolbox_images\Diferent-NuGet-Multiple-Version-Installed.jpg)
+![Syncfusion Xamarin toolbox alert message when different Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin NuGet packages are installed with multiple version in the project](Alert-message-in-Syncfusion-Xamarin-Toolbox_images\Diferent-NuGet-Multiple-Version-Installed.jpg)
 
-To resolve this, manually install all the required versions of Syncfusion NuGet packages in the same version of your project. Then, drag the required Syncfusion component from the Syncfusion Toolbox (Xamarin/.NET MAUI) and drop the render code snippet in the XAML file of your project. Please refer to the following help topics to use the Syncfusion Toolbox:
+To resolve this, manually install all the required versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in the same version of your project. Then, drag the required Syncfusion<sup style="font-size:70%">&reg;</sup>  component from the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox (Xamarin/.NET MAUI) and drop the render code snippet in the XAML file of your project. Please refer to the following help topics to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox:
 
 1. [Xamarin ToolBox](https://help.syncfusion.com/extension/xamarin-extension/toolbox)
 2. [.NET MAUI ToolBox](https://help.syncfusion.com/maui/visual-studio-integration/toolbox-control)

--- a/Extension/Faq/How-to-update-Syncfusion-manual-references-to-Syncfusion-NuGet-packages-in-your-application.md
+++ b/Extension/Faq/How-to-update-Syncfusion-manual-references-to-Syncfusion-NuGet-packages-in-your-application.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: How to update Syncfusion manual references to Syncfusion NuGet packages in your application | Extension | Syncfusion
-description: how to update Syncfusion manual references to Syncfusion NuGet packages in your application?
+title: How to update Syncfusion  manual references to Syncfusion  NuGet packages in your application | Extension | Syncfusion
+description: how to update Syncfusion  manual references to Syncfusion  NuGet packages in your application?
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# How to update Syncfusion manual references to Syncfusion NuGet packages in your application?
+# How to update Syncfusion<sup style="font-size:70%">&reg;</sup>  manual references to Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application?
 
-Follow the steps provided in the given KB for update Syncfusion manual references to Syncfusion NuGet packages in your application. KB link: [https://www.syncfusion.com/kb/8507](https://www.syncfusion.com/kb/8507)
+Follow the steps provided in the given KB for update Syncfusion<sup style="font-size:70%">&reg;</sup>  manual references to Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application. KB link: [https://www.syncfusion.com/kb/8507](https://www.syncfusion.com/kb/8507)
 

--- a/Extension/Faq/The-Syncfusion-templates-do-not-show-up-in-the-new-project-window-of-Visual-Studio.md
+++ b/Extension/Faq/The-Syncfusion-templates-do-not-show-up-in-the-new-project-window-of-Visual-Studio.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: Syncfusion template not shown in new project window of Visual Studio
+title: Syncfusion  template not shown in new project window of Visual Studio
 description: The syncfusion templates do not show up in the new project window of visual studio.  how can to get them installed?
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion template not shown in new project window of Visual Studio
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  template not shown in new project window of Visual Studio
 
-Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension build has been installed in the machine or not.
+Perform the given steps to ensure whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Extension build has been installed in the machine or not.
 
 1. Navigate to the following either one of the location:
 
@@ -38,10 +38,10 @@ Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension b
 
 2. When the above path exists, it means that the ASP.NET MVC Extension build has already been installed in the machine. So now you can install the following Syncfusion
    Extensions manually:
-   * Syncfusion Project Templates
-   * Syncfusion Visual Studio Extensions
+   * Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates
+   * Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Extensions
 
-   ## To Install Syncfusion Project Templates: 
+   ## To Install Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates: 
 
    **Before 17.1.0.32-beta version**
 
@@ -58,7 +58,7 @@ Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension b
 
    **On or After 17.1.0.32-beta version**
 
-   Navigate to the following location and run the “Syncfusion Essential JS1 AspNet MVC VSExtensions.vsix” extension.
+   Navigate to the following location and run the “Syncfusion Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet MVC VSExtensions.vsix” extension.
 
    _{Syncfusion Build installed location}\Utilities\Extensions_
 
@@ -69,7 +69,7 @@ Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension b
 
    ![Syncfusion ASP.NET MVC Project Template VSIX file location](The-Syncfusion-templatesd_images/The-Syncfusion-templatesd-img4.png)
 
-   ## To Install Syncfusion Visual Studio Extension:
+   ## To Install Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Extension:
 
    **Before 17.1.0.32-beta version**
 
@@ -85,6 +85,6 @@ Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension b
 
    **On or After 17.1.0.32-beta version**
 
-   Syncfusion Web Conversion and Migration.vsix extension has been added as a dependency VSIX package to the Syncfusion Essential JS1 AspNet MVC VSExtensions.vsix extension from the **v17.1.0.32- beta** and the Syncfusion Web Conversion and Migration.vsix extension will be installed along with the Syncfusion Essential JS1 AspNet MVC VSExtensions.vsix extension.
+   Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Conversion and Migration.vsix extension has been added as a dependency VSIX package to the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet MVC VSExtensions.vsix extension from the **v17.1.0.32- beta** and the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Conversion and Migration.vsix extension will be installed along with the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> JS1 AspNet MVC VSExtensions.vsix extension.
 
-3. If the respective version of Syncfusion MVC Extension is not installed in the machine, download the Extension setup from the following link.        [http://www.syncfusion.com/downloads/extension/](http://www.syncfusion.com/downloads/extension/)
+3. If the respective version of Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Extension is not installed in the machine, download the Extension setup from the following link.        [http://www.syncfusion.com/downloads/extension/](http://www.syncfusion.com/downloads/extension/)

--- a/Extension/Faq/While-creating-a-new-Syncfusion-project-there-are-now-two-icons-in-the-window-to-select-from.md
+++ b/Extension/Faq/While-creating-a-new-Syncfusion-project-there-are-now-two-icons-in-the-window-to-select-from.md
@@ -1,22 +1,22 @@
 ---
 layout: post
-title: While creating a new Syncfusion project there are now two icons in the window to select from How to get rid of this | Extension | Syncfusion
+title: While creating a new Syncfusion  project there are now two icons in the window to select from How to get rid of this | Extension | Syncfusion
 description: while creating a new syncfusion project there are now two icons in the window to select from. how to get rid of this?
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# While creating a new Syncfusion project there are now two icons in the window to select from. How to get rid of this?
+# While creating a new Syncfusion<sup style="font-size:70%">&reg;</sup>  project there are now two icons in the window to select from. How to get rid of this?
 
-Navigate to Visual Studio Tools->Extensions and Updates. The Installed Syncfusion MVC Extensions are displayed along with its version. Refer to the following screenshot for more information.
+Navigate to Visual Studio Tools->Extensions and Updates. The Installed Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Extensions are displayed along with its version. Refer to the following screenshot for more information.
 
 ![Visual Studio Extension and Updates dialog](While-creating-a-new-Syncfusion-project_images/While-creating-a-new-Syncfusion-project-img1.png)
 
 
 
 1. If Syncfusion.MVC.VsPackage.Web is present more than once, uninstall the Syncfusion.MVC.VSPackage.Web VSIX of that particular version that is no longer in use by clicking the Uninstall button. 
-2. Restart Visual Studio. Now you can see the Syncfusion ASP.NET MVC project template without multiple entries.
+2. Restart Visual Studio. Now you can see the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC project template without multiple entries.
 
    ![Visual Studio new project dialog](While-creating-a-new-Syncfusion-project_images/While-creating-a-new-Syncfusion-project-img2.png)
 

--- a/Extension/Faq/how-to-render-control-after-installing-nuget-packages.md
+++ b/Extension/Faq/how-to-render-control-after-installing-nuget-packages.md
@@ -3,11 +3,11 @@ layout: post
 title: How to render control after installing NuGet Packages | Extension | Syncfusion
 description: how to render control after installing nuget packages?
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # How to render control after installing NuGet Packages?
 
-Follow the steps provided in the given KB to render a control after installing Syncfusion NuGet Packages. KB link: [http://www.syncfusion.com/kb/4077](http://www.syncfusion.com/kb/4077)
+Follow the steps provided in the given KB to render a control after installing Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages. KB link: [http://www.syncfusion.com/kb/4077](http://www.syncfusion.com/kb/4077)
 

--- a/Extension/Frequently-Asked-Questions/How-to-render-control-after-installing-NuGet-Packages.md
+++ b/Extension/Frequently-Asked-Questions/How-to-render-control-after-installing-NuGet-Packages.md
@@ -9,5 +9,5 @@ documentation: ug
 
 # How to render control after installing NuGet Packages?
 
-Follow the steps provided in the given KB to render a control after installing Syncfusion NuGet Packages. KB link: [http://www.syncfusion.com/kb/4077](http://www.syncfusion.com/kb/4077)
+Follow the steps provided in the given KB to render a control after installing Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages. KB link: [http://www.syncfusion.com/kb/4077](http://www.syncfusion.com/kb/4077)
 

--- a/Extension/Frequently-Asked-Questions/The-Syncfusion-templates-do-not-show-up-in-the-new-project-window-of-Visual-Studio-How-can-to-get-them-installed.md
+++ b/Extension/Frequently-Asked-Questions/The-Syncfusion-templates-do-not-show-up-in-the-new-project-window-of-Visual-Studio-How-can-to-get-them-installed.md
@@ -3,13 +3,13 @@ layout: post
 title: The-Syncfusion-templates-do-not-show-up-in-the-new-project-window-of-Visual-Studio-How-can-to-get-them-installed
 description: the syncfusion templates do not show up in the new project window of visual studio.  how can to get them installed?
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# The Syncfusion templates do not show up in the new project window of Visual Studio.  How can to get them installed?
+# The Syncfusion<sup style="font-size:70%">&reg;</sup>  templates do not show up in the new project window of Visual Studio.  How can to get them installed?
 
-Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension build has been installed in the machine or not.
+Perform the given steps to ensure whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC Extension build has been installed in the machine or not.
 
 1. Navigate to the following location:
 
@@ -26,10 +26,10 @@ Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension b
 
 2. When the above path exists, it means that the ASP.NET MVC Extension build has already been installed in the machine. So now you can install the following Syncfusion
    Extensions manually:
-   * Syncfusion Project Templates
-   * Syncfusion Visual Studio Extensions
+   * Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates
+   * Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Extensions
 
-   ## To Install Syncfusion Project Templates: 
+   ## To Install Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates: 
    Navigate to the following location and run the “Syncfusion.MVC.VSPackage.Web.vsix” extension.
 
    _{Syncfusion Build installed location}\Utilities\Extensions\ASP.NET MVC\Project Templates\Web\{Visual Studio Version}_
@@ -40,7 +40,7 @@ Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension b
 
    ![Syncfusion Project Template VSIX file location](The-Syncfusion-templatesd_images/The-Syncfusion-templatesd-img2.png)
 
-   ## To Install Syncfusion Visual Studio Extension:
+   ## To Install Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Extension:
    Navigate to the following Location and run the “Syncfusion Web Conversion and Migration.vsix” extension. 
 
    _{Syncfusion Build installed location}\Utilities\Extensions\Project Conversion\{Visual Studio Version}_
@@ -54,4 +54,4 @@ Perform the given steps to ensure whether the Syncfusion ASP.NET MVC Extension b
 
 
 
-3. If the respective version of Syncfusion MVC Extension is not installed in the machine, download the Extension setup from the following link.        [http://www.syncfusion.com/downloads/extension/](http://www.syncfusion.com/downloads/extension/)
+3. If the respective version of Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Extension is not installed in the machine, download the Extension setup from the following link.        [http://www.syncfusion.com/downloads/extension/](http://www.syncfusion.com/downloads/extension/)

--- a/Extension/Frequently-Asked-Questions/While-creating-a-new-Syncfusion-project-there-are-now-two-icons-in-the-window-to-select-from-How-to-get-rid-of-this.md
+++ b/Extension/Frequently-Asked-Questions/While-creating-a-new-Syncfusion-project-there-are-now-two-icons-in-the-window-to-select-from-How-to-get-rid-of-this.md
@@ -3,20 +3,20 @@ layout: post
 title: While-creating-a-new-Syncfusion-project-there-are-now-two-icons-in-the-window-to-select-from-How-to-get-rid-of-this
 description: while creating a new syncfusion project there are now two icons in the window to select from. how to get rid of this?
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# While creating a new Syncfusion project there are now two icons in the window to select from. How to get rid of this?
+# While creating a new Syncfusion<sup style="font-size:70%">&reg;</sup>  project there are now two icons in the window to select from. How to get rid of this?
 
-Navigate to Visual Studio Tools->Extensions and Updates. The Installed Syncfusion MVC Extensions are displayed along with its version. Refer to the following screenshot for more information.
+Navigate to Visual Studio Tools->Extensions and Updates. The Installed Syncfusion<sup style="font-size:70%">&reg;</sup>  MVC Extensions are displayed along with its version. Refer to the following screenshot for more information.
 
 ![Visual Studio Extension and Updates dialog](While-creating-a-new-Syncfusion-project_images/While-creating-a-new-Syncfusion-project-img1.png)
 
 
 
 1. If Syncfusion.MVC.VsPackage.Web is present more than once, uninstall the Syncfusion.MVC.VSPackage.Web VSIX of that particular version that is no longer in use by clicking the Uninstall button. 
-2. Restart Visual Studio. Now you can see the Syncfusion ASP.NET MVC project template without multiple entries.
+2. Restart Visual Studio. Now you can see the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET MVC project template without multiple entries.
 
    ![Visual Studio new project dialog](While-creating-a-new-Syncfusion-project_images/While-creating-a-new-Syncfusion-project-img2.png)
 

--- a/Extension/Javascript-Extension/Visual-Studio-Code/code-snippet.md
+++ b/Extension/Javascript-Extension/Visual-Studio-Code/code-snippet.md
@@ -1,53 +1,53 @@
 ---
 layout: post
 title: Code Snippet | Angular | Syncfusion
-description: Code snippet adding a Syncfusion Angular component with various features in the HTML code editor file of the Angular Application.
+description: Code snippet adding a Syncfusion  Angular component with various features in the HTML code editor file of the Angular Application.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Add Syncfusion Angular component in the Angular application
+# Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component in the Angular application
 
-The Syncfusion Angular code snippet utility for Visual Studio Code provides snippets for adding a Syncfusion Angular component with various features in the html code editor file of the Angular Application.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular code snippet utility for Visual Studio Code provides snippets for adding a Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component with various features in the html code editor file of the Angular Application.
 
-   > The Syncfusion Angular code snippet is available from Essential Studio 2021 Vol 3 (`v19.3.0.43`).
+   > The Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular code snippet is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  2021 Vol 3 (`v19.3.0.43`).
 
-## Add a Syncfusion Angular component
+## Add a Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component
 
-The following steps help you to use the Syncfusion Angular code snippet in your Angular Application.
+The following steps help you to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular code snippet in your Angular Application.
 
 1. In Visual Studio Code, open an existing Angular Application or create a new Angular Application.
 
-2. Open the html file that you need and place the cursor in required place where you want to add Syncfusion component.
+2. Open the html file that you need and place the cursor in required place where you want to add Syncfusion<sup style="font-size:70%">&reg;</sup>  component.
 
-3. You can find the Syncfusion Angular component with the various features by typing the **ejs** word in the format shown below.
+3. You can find the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component with the various features by typing the **ejs** word in the format shown below.
 
     ```bash
     ejs-<Syncfusion component name>-<Syncfusion component feature>
 
     For Example, ejs-grid-grouping
     ```
-4. Choose the Syncfusion component and click the **Enter** or **Tab** key, the Syncfusion Angular component will be added in the html file.
+4. Choose the Syncfusion<sup style="font-size:70%">&reg;</sup>  component and click the **Enter** or **Tab** key, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component will be added in the html file.
 
     ![Code Snippet](images/codesnippet.gif)
 
-5. After adding the Syncfusion Angular component to the html file, use the tab key to fill in the required values to render the component with data. You can also find the Syncfusion help link at the top of the added snippet to learn more about the new Syncfusion Angular component feature.
+5. After adding the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component to the html file, use the tab key to fill in the required values to render the component with data. You can also find the Syncfusion<sup style="font-size:70%">&reg;</sup>  help link at the top of the added snippet to learn more about the new Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component feature.
 
     ![Help](images/Help.png)
 
 ## Configure Angular application with Syncfusion
 
-The Syncfusion Angular snippet only add the code snippet alone in the html file. You need to configure the Angular application with Syncfusion by adding the required Syncfusion Angular NPM, component modules, and themes by manually. To configure, refer the steps below:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular snippet only add the code snippet alone in the html file. You need to configure the Angular application with Syncfusion<sup style="font-size:70%">&reg;</sup>  by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular NPM, component modules, and themes by manually. To configure, refer the steps below:
 
-1. Open the Angular package.json file and add the required Syncfusion Angular individual NPM package(s) for the Syncfusion Angular components manually. Then navigate to the packages.json file location in the command prompt and run the ***npm install*** command to restore all the Syncfusion Angular NPM packages.
+1. Open the Angular package.json file and add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular individual NPM package(s) for the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular components manually. Then navigate to the packages.json file location in the command prompt and run the ***npm install*** command to restore all the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular NPM packages.
 
     ![NPM Package](images/NPM.png)
 
-2. Open your module file and add the required Syncfusion Angular component(s) module entries to render the Syncfusion components in your application. 
+2. Open your module file and add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component(s) module entries to render the Syncfusion<sup style="font-size:70%">&reg;</sup>  components in your application. 
 
     ![Module](images/Module.png)
 
-3. Add the Syncfusion Angular [theme](https://ej2.syncfusion.com/documentation/appearance/theme/) entry in the **style.css** file.
+3. Add the Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular [theme](https://ej2.syncfusion.com/documentation/appearance/theme/) entry in the **style.css** file.
 
     ![Themes](images/Themes-Snippet.png)

--- a/Extension/Javascript-Extension/Visual-Studio-Code/create-project.md
+++ b/Extension/Javascript-Extension/Visual-Studio-Code/create-project.md
@@ -1,17 +1,17 @@
 ---
 layout: post
 title: Project Templates | Angular | Syncfusion
-description: Syncfusion provides Visual Studio Code Project Templates for Angular platform to create the Syncfusion Angular Application using Syncfusion components
+description: Syncfusion  provides Visual Studio Code Project Templates for Angular platform to create the Syncfusion  Angular Application using Syncfusion components
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
 ---
 
-# Create project With Syncfusion Visual Studio Code project Templates
+# Create project With Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Code project Templates
 
-Syncfusion provides **project templates** for **VisualStudio Code** to create Syncfusion Web applications. Syncfusion Web Project template creates applications with the selected Framework(React, Angular, and Vue), required Syncfusion NPM packages, component render code for the Grid, Chart, Scheduler components, and the style for making development easier with Syncfusion components.
+Syncfusion provides **project templates** for **VisualStudio Code** to create Syncfusion<sup style="font-size:70%">&reg;</sup>  Web applications. Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Project template creates applications with the selected Framework(React, Angular, and Vue), required Syncfusion<sup style="font-size:70%">&reg;</sup>  NPM packages, component render code for the Grid, Chart, Scheduler components, and the style for making development easier with Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
-   > The Syncfusion Visual Studio Code project template provides support for Web project templates from v18.3.0.47.
+   > The Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Code project template provides support for Web project templates from v18.3.0.47.
 
 The following steps help you create **Syncfusion Web Applications** through the **Visual Studio Code:**
 
@@ -19,7 +19,7 @@ The following steps help you create **Syncfusion Web Applications** through the 
 
     ![CreateProjectPalette](images/CreateProjectPalette.png)
 
-2. Select Syncfusion Web Template Studio: Launch and then press Enter. The Template Studio wizard for configuring the Syncfusion Web app will appear. Provide the require Project Name and Path to create the new Syncfusion Web application along with any one of the Framework(React, Angular, and Vue).
+2. Select Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Template Studio: Launch and then press Enter. The Template Studio wizard for configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web app will appear. Provide the require Project Name and Path to create the new Syncfusion<sup style="font-size:70%">&reg;</sup>  Web application along with any one of the Framework(React, Angular, and Vue).
 
     ![ProjectLocation](images/ProjectLocationName.png)
 
@@ -34,7 +34,7 @@ The following steps help you create **Syncfusion Web Applications** through the 
 
     ![Themes](images/Themes.png)
 
-5. The created Syncfusion Web App is configured with the Syncfusion NPM packages, styles, and the component render code for the Syncfusion component added.
+5. The created Syncfusion<sup style="font-size:70%">&reg;</sup>  Web App is configured with the Syncfusion<sup style="font-size:70%">&reg;</sup>  NPM packages, styles, and the component render code for the Syncfusion<sup style="font-size:70%">&reg;</sup>  component added.
 
     For **React**
 

--- a/Extension/Javascript-Extension/Visual-Studio-Code/download-and-installation.md
+++ b/Extension/Javascript-Extension/Visual-Studio-Code/download-and-installation.md
@@ -3,7 +3,7 @@ layout: post
 title: Download and Installation | Javascript | Syncfusion
 description: How to download and install the Syncfusion Web Visual Studio Extensions from Visual Studio Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -13,11 +13,11 @@ Syncfusion publishes the Visual Studio Code extension in [Visual Studio Code mar
 
 ## Prerequisites
 
-The following prerequisites software needs to be installed for the Syncfusion Web extension installation and for creating the Syncfusion Web applications along with any one of the Framework(React, Angular, and Vue).
+The following prerequisites software needs to be installed for the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web extension installation and for creating the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web applications along with any one of the Framework(React, Angular, and Vue).
 
 * [Visual Studio Code](https://code.visualstudio.com/download)
 
- > The minimum version of the Visual Studio Code is 1.38.0 to use the Syncfusion Web Extension.
+ > The minimum version of the Visual Studio Code is 1.38.0 to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Extension.
 
 * [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
 
@@ -25,7 +25,7 @@ The following prerequisites software needs to be installed for the Syncfusion We
 
 ## Install through the Visual Studio Code Extensions
 
-The following steps explain how to install the Syncfusion Web extensions from Visual Studio Code Extensions.
+The following steps explain how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web extensions from Visual Studio Code Extensions.
 
 1. Open Visual Studio Code.
 
@@ -39,13 +39,13 @@ The following steps explain how to install the Syncfusion Web extensions from Vi
 
 5. After the installation, reload the Visual Studio Code using the **Reload Required** in Visual Studio Code palette.
 
-6. Now, use the Syncfusion Web extensions from the Visual Studio Code palette.
+6. Now, use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web extensions from the Visual Studio Code palette.
 
      ![CreateProjectPalette](images/CreateProjectPalette.png)
 
 ## Install from the Visual Studio Code Marketplace
 
-The following steps explain how to download Syncfusion Web applications from the Visual Studio Code Marketplace and install them.
+The following steps explain how to download Syncfusion<sup style="font-size:70%">&reg;</sup>  Web applications from the Visual Studio Code Marketplace and install them.
 
 1. Open the [Syncfusion Web Extension](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Web-VSCode-Extensions)
 
@@ -55,6 +55,6 @@ The following steps explain how to download Syncfusion Web applications from the
 
 4. After the installation, reload the Visual Studio Code using the Reload Required in Visual Studio Code palette.
 
-5. Now, use the Syncfusion Web extensions from the Visual Studio Code palette.
+5. Now, use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Web extensions from the Visual Studio Code palette.
 
      ![CreateProjectPalette](images/CreateProjectPalette.png)

--- a/Extension/Javascript-Extension/Visual-Studio-Code/overview.md
+++ b/Extension/Javascript-Extension/Visual-Studio-Code/overview.md
@@ -1,18 +1,18 @@
 ---
 layout: post
 title: Web VSCode Extension | Extension | Syncfusion
-description: Syncfusion Essential Studio Web extension for Visual Studio Code allows you to create a web project with any one of the Frameworks(React, Angular, and Vue).
+description: Syncfusion  Essential Studio Web extension for Visual Studio Code allows you to create a web project with any one of the Frameworks(React, Angular, and Vue).
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Web Extension for Visual Studio Code
 
-The Syncfusion Essential Studio Web extension for Visual Studio Code allows you to use the Syncfusion JavaScript components(React, Angular, and Vue) easily by configuring the Syncfusion NPM packages and themes.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  Web extension for Visual Studio Code allows you to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  JavaScript components(React, Angular, and Vue) easily by configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  NPM packages and themes.
 
-The Syncfusion Web Extension provides the following support in Visual Studio Code:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Web Extension provides the following support in Visual Studio Code:
 
-[Project-Template](https://help.syncfusion.com/extension/javascript-extension/visual-studio-code/create-project): Creates Syncfusion Web applications by adding the required Syncfusion JavaScript components.
+[Project-Template](https://help.syncfusion.com/extension/javascript-extension/visual-studio-code/create-project): Creates Syncfusion<sup style="font-size:70%">&reg;</sup>  Web applications by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  JavaScript components.
 
-[Code Snippet](/extension/javascript-extension/visual-studio-code/code-snippet):  Adds a Syncfusion Angular component with various features to the Angular Application's HTML code editor.
+[Code Snippet](/extension/javascript-extension/visual-studio-code/code-snippet):  Adds a Syncfusion<sup style="font-size:70%">&reg;</sup>  Angular component with various features to the Angular Application's HTML code editor.

--- a/Extension/NETMAUI-Extension/Visual-Studio-Code/code-snippet.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio-Code/code-snippet.md
@@ -1,53 +1,53 @@
 ---
 layout: post
 title: Code Snippets - .NET MAUI Extension Visual Studio Code | Syncfusion
-description: Learn here all about how to use code snippet utility of Syncfusion .NET MAUI Extension for Visual Studio Code and much more.
+description: Learn here all about how to use code snippet utility of Syncfusion.NET MAUI Extension for Visual Studio Code and much more.
 platform: MAUI
 component: Common
 documentation: ug
 ---
 
-# Add Syncfusion .NET MAUI component in the .NET MAUI application
+# Add Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI component in the .NET MAUI application
 
-The Syncfusion .NET MAUI code sample utility for Visual Studio Code provides sample for easily inserting Syncfusion .NET MAUI components with various features into the .NET MAUI Application's XAML code editor.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI code sample utility for Visual Studio Code provides sample for easily inserting Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components with various features into the .NET MAUI Application's XAML code editor.
 
-N> The Syncfusion .NET MAUI code sample is available from Essential Studio 2024 Volume 1 (`v25.1.35`) onwards.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI code sample is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  2024 Volume 1 (`v25.1.35`) onwards.
 
-## Add a Syncfusion .NET MAUI component
+## Add a Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI component
 
-The following instructions outline the process of using the Syncfusion .NET MAUI code snippet in your .NET MAUI application.
+The following instructions outline the process of using the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI code snippet in your .NET MAUI application.
 
 1.	In Visual Studio Code, either open an existing .NET MAUI application or create a new .NET MAUI Application.
 
-2.	Open the XAML file you require and position the cursor where you want to add the Syncfusion component.
+2.	Open the XAML file you require and position the cursor where you want to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  component.
 
-3.	To access Syncfusion .NET MAUI components with various features, type the **sf** word in the specified format.
+3.	To access Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components with various features, type the **sf** word in the specified format.
 
 ```
 sf<Syncfusion component name>-<Syncfusion component feature>
 For Example, sf-datagrid-grouping
 ```
 
-4.	Select the desired Syncfusion component and press the **Enter** or **Tab** key to add the Syncfusion .NET MAUI component to the XAML file. 
+4.	Select the desired Syncfusion<sup style="font-size:70%">&reg;</sup>  component and press the **Enter** or **Tab** key to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI component to the XAML file. 
 
       ![Code Snippet](images/MAUI_CodeSnippets.gif)
 
-5.	After adding the Syncfusion .NET MAUI component to the XAML file, We've included instructions in the **TODO** section for your reference. This will guide you in determining whether to add the the View Model file or if only add namespace and NuGet entries to run the Syncfusion components.
+5.	After adding the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI component to the XAML file, We've included instructions in the **TODO** section for your reference. This will guide you in determining whether to add the the View Model file or if only add namespace and NuGet entries to run the Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
      ![Comment](images/Comment.png)
 
-6.	You can also find a Syncfusion help link at the top of the added sample to learn more about the new Syncfusion .NET MAUI component feature.
+6.	You can also find a Syncfusion<sup style="font-size:70%">&reg;</sup>  help link at the top of the added sample to learn more about the new Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI component feature.
 
      ![Help](images/Help.png)
 
 ## Configure .NET MAUI application with Syncfusion
 
-The Syncfusion .NET MAUI snippet inserts code into the XAML file. However, you need to configure the .NET MAUI project with Syncfusion by installing the Syncfusion .NET MAUI NuGet package and adding the appropriate namespace. To configure, follow these steps:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI snippet inserts code into the XAML file. However, you need to configure the .NET MAUI project with Syncfusion<sup style="font-size:70%">&reg;</sup>  by installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI NuGet package and adding the appropriate namespace. To configure, follow these steps:
 
-1.	Open the .NET MAUI application file and manually add the necessary Syncfusion .NET MAUI individual NuGet package(s) as a package reference for the Syncfusion .NET MAUI components. We've included a commented code sample indicating the corresponding NuGet package entry for each component. Copy the NuGet package entry and paste it into your .NET MAUI project file. This NuGet package will be automatically restored during the build or save process of the project.
+1.	Open the .NET MAUI application file and manually add the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI individual NuGet package(s) as a package reference for the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components. We've included a commented code sample indicating the corresponding NuGet package entry for each component. Copy the NuGet package entry and paste it into your .NET MAUI project file. This NuGet package will be automatically restored during the build or save process of the project.
 
      ![NuGet Package](images/NuGetEntry.gif)
 
-2.	To integrate Syncfusion components into your application, go to the XAML file and insert the necessary Syncfusion .NET MAUI namespace entries. We've included a commented code sample indicating the corresponding namespace entry for each component. Copy the namespace entry and paste it into your XAML file.
+2.	To integrate Syncfusion<sup style="font-size:70%">&reg;</sup>  components into your application, go to the XAML file and insert the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI namespace entries. We've included a commented code sample indicating the corresponding namespace entry for each component. Copy the namespace entry and paste it into your XAML file.
 
     ![Namespace](images/NamespaceEntry.gif)

--- a/Extension/NETMAUI-Extension/Visual-Studio-Code/create-project.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio-Code/create-project.md
@@ -1,29 +1,29 @@
 ---
 layout: post
 title: Create Projects using Project Templates via Extensions | Syncfusion
-description: Learn here about how to create syncfusion .NET MAUI application using Syncfusion .NET MAUI Extension for Visual Studio Code.
+description: Learn here about how to create syncfusion .NET MAUI application using Syncfusion  .NET MAUI Extension for Visual Studio Code.
 platform: MAUI
 component: Common
 documentation: ug
 ---
 
-# Creating a Syncfusion .NET MAUI application
+# Creating a Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application
 
-Syncfusion offers the .NET MAUI Project Template for building .NET MAUI applications using Syncfusion components in Visual Studio Code. This template includes all the necessary Syncfusion components, NuGet references, namespaces, and code snippets required for developing .NET MAUI applications with Syncfusion. The **.NET MAUI Project Template** comes with a project wizard to streamline the application creation process using Syncfusion components.
+Syncfusion offers the .NET MAUI Project Template for building .NET MAUI applications using Syncfusion<sup style="font-size:70%">&reg;</sup>  components in Visual Studio Code. This template includes all the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  components, NuGet references, namespaces, and code snippets required for developing .NET MAUI applications with Syncfusion. The **.NET MAUI Project Template** comes with a project wizard to streamline the application creation process using Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
-N> Syncfusion Visual Studio Code project templates now support .NET MAUI project templates starting from `v25.1.35`.
+N> Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Code project templates now support .NET MAUI project templates starting from `v25.1.35`.
 
 The following steps below will assist you to create your **Syncfusion .NET MAUI Application** through **Visual Studio Code:**
 
-1.	To create a Syncfusion .NET MAUI application in Visual Studio Code, open the command palette by pressing **Ctrl+Shift+P**. Then, search for **Syncfusion** in the Visual Studio Code palette to access the templates provided by Syncfusion.
+1.	To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application in Visual Studio Code, open the command palette by pressing **Ctrl+Shift+P**. Then, search for **Syncfusion** in the Visual Studio Code palette to access the templates provided by Syncfusion.
 
     ![CreateProjectPalette](images/CreateProjectPalette.png)
 
-2.	Select **Syncfusion .NET MAUI Template Studio: Launch** and press **Enter**. This will launch the Template Studio wizard for configuring the Syncfusion .NET MAUI application. Enter a unique **Project Name** to identify your application, and then specify the **Project Location**, which is the directory where your project files will be saved. Ensure that the chosen location meets your project's needs.
+2.	Select **Syncfusion .NET MAUI Template Studio: Launch** and press **Enter**. This will launch the Template Studio wizard for configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application. Enter a unique **Project Name** to identify your application, and then specify the **Project Location**, which is the directory where your project files will be saved. Ensure that the chosen location meets your project's needs.
 
     ![CreateProject](images/TemplateStudioWizard.png)
 
-3.	To select a component, click the **Next** button or the **Components** tab. From there, you can add the desired Syncfusion .NET MAUI components to your application. Simply choose the necessary Syncfusion .NET MAUI components for your project.
+3.	To select a component, click the **Next** button or the **Components** tab. From there, you can add the desired Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components to your application. Simply choose the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components for your project.
 
     ![SelectComponents](images/MAUIControlSelection.gif)
 
@@ -49,15 +49,15 @@ The following steps below will assist you to create your **Syncfusion .NET MAUI 
 
     ![ProjectSummary](images/MAUIProjectSummary.png)
 
-5.	Click the **Create** button to generate the Syncfusion .NET MAUI application. The created application includes the necessary Syncfusion NuGet packages and rendering code for the selected Syncfusion components.
+5.	Click the **Create** button to generate the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application. The created application includes the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages and rendering code for the selected Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
-6.  To view the Syncfusion components in your application, run it by pressing **F5** or selecting **Run > Start Debugging**. Then, search for **.NET MAUI** and select it to launch the application.
+6.  To view the Syncfusion<sup style="font-size:70%">&reg;</sup>  components in your application, run it by pressing **F5** or selecting **Run > Start Debugging**. Then, search for **.NET MAUI** and select it to launch the application.
 
     ![Debug](images/Debug.gif)
 
     N> **Note:** If the .NET MAUI extension is a preview version, the debugger will be listed as **.NET MAUI**. However, if the .NET MAUI extension is stable, this configuration will be replaced with **C#**.
 
-7.	The Syncfusion .NET MAUI application is configured with the latest Syncfusion .NET MAUI NuGet packages version, namespaces, and component rendering code for Syncfusion components.
+7.	The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application is configured with the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI NuGet packages version, namespaces, and component rendering code for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
-8.	If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+8.	If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
 

--- a/Extension/NETMAUI-Extension/Visual-Studio-Code/download-and-installation.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio-Code/download-and-installation.md
@@ -11,7 +11,7 @@ documentation: ug
 Syncfusion publishes the Visual Studio Code extension on the [Visual Studio Code marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.MAUI-VSCode-Extensions). You can install it directly from Visual Studio Code or download and install it from the Visual Studio Code marketplace.
 
 **Prerequisites**
-The following software prerequisites must be installed to install the Syncfusion .NET MAUI extension, as well as for creating and adding snippets in Syncfusion .NET MAUI applications.
+The following software prerequisites must be installed to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extension, as well as for creating and adding snippets in Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI applications.
 
 * [Visual Studio Code 1.87.1 or later](https://code.visualstudio.com/download)
 
@@ -20,13 +20,13 @@ The following software prerequisites must be installed to install the Syncfusion
 * [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)
 
 ## Install through the Visual Studio Code Extensions
-The following instructions outline the process of installing the Syncfusion .NET MAUI extensions from Visual Studio Code Extensions.
+The following instructions outline the process of installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extensions from Visual Studio Code Extensions.
 
 1.	Open Visual Studio Code.
 
 2.	Navigate to **View > Extensions**, and the Manage Extensions option will appear on the left side of the window.
 
-3.	By entering the keyword **Syncfusion .NET MAUI** in the search box, you can find the Syncfusion .NET MAUI Visual Studio Code extension in the Visual Studio Code Marketplace.
+3.	By entering the keyword **Syncfusion .NET MAUI** in the search box, you can find the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Visual Studio Code extension in the Visual Studio Code Marketplace.
 
 4.	Install the **.NET MAUI VSCode Extensions - Syncfusion** extension by clicking the Install button.
 
@@ -34,30 +34,30 @@ The following instructions outline the process of installing the Syncfusion .NET
 
     ![Reload-Window](images/Reload-Window.png)
 
-6.	You can now create a new Syncfusion .NET MAUI application using the Syncfusion .NET MAUI extensions from the Visual Studio Code Palette. Find the **Syncfusion .NET MAUI Template Studio: Launch** option among the Visual Studio Code commands to open the Syncfusion .NET MAUI Template Studio wizard.
+6.	You can now create a new Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application using the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extensions from the Visual Studio Code Palette. Find the **Syncfusion .NET MAUI Template Studio: Launch** option among the Visual Studio Code commands to open the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Template Studio wizard.
 
     ![CreateProjectPalette](images/CreateProjectPalette.png)
 
 ## Install from the Visual Studio Code Marketplace
 
-The following instructions outline the process of downloading and installing Syncfusion .NET MAUI applications from the Visual Studio Code Marketplace.
+The following instructions outline the process of downloading and installing Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI applications from the Visual Studio Code Marketplace.
 
 1.	Open [Syncfusion .NET MAUI Code Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.MAUI-VSCode-Extensions) in Visual Studio Code Marketplace.
 
-2.	Select **Install** from the Visual Studio Code Marketplace. A popup window appears in your browser with information like **Open Visual Studio Code**. Clicking **Open Visual Studio Code** will launch the Syncfusion .NET MAUI Extension in Visual Studio Code.
+2.	Select **Install** from the Visual Studio Code Marketplace. A popup window appears in your browser with information like **Open Visual Studio Code**. Clicking **Open Visual Studio Code** will launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Extension in Visual Studio Code.
 
 3.	Install the **.NET MAUI VSCode Extensions - Syncfusion** extension by clicking the Install button.
 
 4.	After installation, reload Visual Studio Code by executing the **Reload Window** command from the Visual Studio Code palette. Access the command palette by pressing **Ctrl+Shift+P** and locating the Reload Window command among the Visual Studio Code commands.
 
     ![Reload-Window](images/Reload-Window.png)
-5.	You can now initiate the creation of a new Syncfusion .NET MAUI application using the Syncfusion .NET MAUI extensions from the Visual Studio Code Palette. Locate the **Syncfusion .NET MAUI Template Studio: Launch** option among the Visual Studio Code commands to open the Syncfusion .NET MAUI Template Studio wizard.
+5.	You can now initiate the creation of a new Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application using the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extensions from the Visual Studio Code Palette. Locate the **Syncfusion .NET MAUI Template Studio: Launch** option among the Visual Studio Code commands to open the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Template Studio wizard.
 
     ![CreateProjectPalette](images/CreateProjectPalette.png)
 
 ## Manually Installing an Extension in Visual Studio Code
 
-The following instructions detail the manual installation process of the Syncfusion .NET MAUI extensions in Visual Studio Code.
+The following instructions detail the manual installation process of the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extensions in Visual Studio Code.
 
 1.	To install the extension manually, download the **SyncfusionInc..NET-MAUI-VSCode-Extensions.vsix** file from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.MAUI-VSCode-Extensions). Then, install it from a local file within VS Code.
 

--- a/Extension/NETMAUI-Extension/Visual-Studio-Code/overview.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio-Code/overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Syncfusion .NET MAUI Extension for Visual Studio Code | Syncfusion
-description: Learn here all about introduction on Syncfusion .NET MAUI extension for Visual Studio Code which made integration made ease.
+description: Learn here all about introduction on Syncfusion  .NET MAUI extension for Visual Studio Code which made integration made ease.
 platform: MAUI
 component: Common
 documentation: ug
@@ -9,10 +9,10 @@ documentation: ug
 
 # Overview of .NET MAUI Extension for Visual Studio Code
 
-The [Syncfusion .NET MAUI](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.MAUI-VSCode-Extensions) Extension for Visual Studio Code simplifies the use of Syncfusion .NET MAUI components by configuring the required Syncfusion .NET MAUI NuGet packages. This extension streamlines development by providing developers with easy access to the powerful features and functionalities of Syncfusion .NET MAUI components, saving time and effort.
+The [Syncfusion .NET MAUI](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.MAUI-VSCode-Extensions) Extension for Visual Studio Code simplifies the use of Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components by configuring the required Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI NuGet packages. This extension streamlines development by providing developers with easy access to the powerful features and functionalities of Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components, saving time and effort.
 
-The Syncfusion .NET MAUI Extension offers the following support in Visual Studio Code: 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Extension offers the following support in Visual Studio Code: 
 
-**Project Template:** Creates Syncfusion .NET MAUI applications with the necessary Syncfusion components and configurations for development.
+**Project Template:** Creates Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI applications with the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  components and configurations for development.
 
-**Code Snippet:** Adds a Syncfusion .NET MAUI component with multiple features into the .NET MAUI Application's XAML code editor.
+**Code Snippet:** Adds a Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI component with multiple features into the .NET MAUI Application's XAML code editor.

--- a/Extension/NETMAUI-Extension/Visual-Studio/Syncfusion-Notifications.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications of .NET MAUI Extension | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in .NET MAUI applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in .NET MAUI applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> .NET MAUI**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> .NET MAUI**
 
 ![Option Page](images/maui-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your .NET MAUI application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your .NET MAUI application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/maui-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/maui-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio .NET MAUI,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your .NET MAUI development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio<sup style="font-size:70%">&reg;</sup> .NET MAUI,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your .NET MAUI development projects.
 
 ![Build Notification](images/maui-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your .NET MAUI application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your .NET MAUI application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/maui-invalid.png)
 

--- a/Extension/NETMAUI-Extension/Visual-Studio/Toolbox-Control.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio/Toolbox-Control.md
@@ -1,47 +1,47 @@
 ---
 layout: post
 title: Toolbox Control | .NET MAUI | Syncfusion
-description: Syncfusion .NET MAUI Toolbox to add the Syncfusion .NET MAUI (.NET MAUI.Forms) controls in your project without coding in the Visual Studio designer.
+description: Syncfusion  .NET MAUI Toolbox to add the Syncfusion  .NET MAUI (.NET MAUI.Forms) controls in your project without coding in the Visual Studio designer.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Toolbox for .NET MAUI 
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox for .NET MAUI 
 
-The Syncfusion Visual Studio Toolbox for the .NET MAUI platform is a valuable resource for developers seeking to seamlessly incorporate the Syncfusion .NET MAUI components into their applications. Designed to be compatible with Visual Studio 2022, this toolbox offers a streamlined workflow, simplifying the integration and configuration process of Syncfusion components.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Visual Studio Toolbox for the .NET MAUI platform is a valuable resource for developers seeking to seamlessly incorporate the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components into their applications. Designed to be compatible with Visual Studio 2022, this toolbox offers a streamlined workflow, simplifying the integration and configuration process of Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
-I> The Syncfusion .NET MAUI Toolbox supports Visual Studio 2022 and is available from Essential Studio 2023 Volume 2(v22.1.34) onwards.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Toolbox supports Visual Studio 2022 and is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  2023 Volume 2(v22.1.34) onwards.
 
 > To check whether the **.NET MAUI Extensions - Syncfusion** extension is installed or not in Visual Studio Extension Manager by navigating to **Extension > Manage Extensions > Installed** for Visual Studio 2022. If this extension is not installed, follow the steps outlined in the [download and installation](download-and-installation) help topic to install the extension.
 
-## Launching Syncfusion .NET MAUI Toolbox from the Syncfusion menu
+## Launching Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Toolbox from the Syncfusion<sup style="font-size:70%">&reg;</sup>  menu
 
-To launch the Syncfusion .NET MAUI Toolbox from the Syncfusion menu in Visual Studio 2022, follow these steps: 
+To launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Toolbox from the Syncfusion<sup style="font-size:70%">&reg;</sup>  menu in Visual Studio 2022, follow these steps: 
 1. Open Visual Studio 2022. 
 2. Go to the **Extensions** menu at the top of the Visual Studio window. 
 3. Click on **Syncfusion** within the **Extensions** menu. 
-4. In the Syncfusion submenu, locate and click on **Essential Studio for .NET MAUI**. 
+4. In the Syncfusion<sup style="font-size:70%">&reg;</sup>  submenu, locate and click on **Essential Studio for .NET MAUI**. 
 5. From the **Essential Studio for .NET MAUI** submenu, select **Launch .NET MAUI Toolbox**.
-This toolbox provides a set of tools and features to easily incorporate Syncfusion .NET MAUI components into your .NET MAUI application.
+This toolbox provides a set of tools and features to easily incorporate Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components into your .NET MAUI application.
 
-   ![Syncfusion .NET MAUI Custom Toolbox via Syncfusion menu](images/ToolboxSyncfusionMenu.png)
+   ![Syncfusion .NET MAUI Custom Toolbox via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](images/ToolboxSyncfusionMenu.png)
 
-## Launching Syncfusion .NET MAUI Toolbox from the View menu
+## Launching Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Toolbox from the View menu
 
-To launch the Syncfusion .NET MAUI Toolbox from the View menu in Visual Studio 2022, simply follow these steps:
+To launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Toolbox from the View menu in Visual Studio 2022, simply follow these steps:
 1. Open Visual Studio 2022.
 2. At the top menu, click on **View**.
 3. From the drop-down menu, select **Other Windows**.
 4. In the sub-menu that appears, click on **Syncfusion .NET MAUI Toolbox**.
-This toolbox provides a set of tools and features to easily incorporate Syncfusion .NET MAUI components into your .NET MAUI application.
+This toolbox provides a set of tools and features to easily incorporate Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components into your .NET MAUI application.
 
    ![Syncfusion .NET MAUI Custom Toolbox view menu](images/ToolboxViewMenu.png)
 
-## Add Syncfusion .NET MAUI Toolbox Components
+## Add Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Toolbox Components
    
-To incorporate Syncfusion .NET MAUI components into your XAML design file, you can easily add them by dragging and dropping them from the toolbox. This intuitive approach automatically inserts the component's code sample and namespace into your XAML file, while also taking care of installing necessary NuGet packages.
+To incorporate Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components into your XAML design file, you can easily add them by dragging and dropping them from the toolbox. This intuitive approach automatically inserts the component's code sample and namespace into your XAML file, while also taking care of installing necessary NuGet packages.
 
    ![Syncfusion .NET MAUI Toolbox Wizard](images/ToolboxComponents.gif)
 
-Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.

--- a/Extension/NETMAUI-Extension/Visual-Studio/download-and-installation.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio/download-and-installation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Download and Installation of .NET MAUI Extension | Syncfusion
-description: Check out the documentation for download and installation of Syncfusion .NET MAUI Extension for Visual Studio.
+description: Check out the documentation for download and installation of Syncfusion  .NET MAUI Extension for Visual Studio.
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
@@ -16,7 +16,7 @@ Syncfusion publishes the Visual Studio extension in the below Visual Studio mark
 
 ## Prerequisites
 
-The following software prerequisites must be installed to install the Syncfusion .NET MAUI extension, as well as for creating, adding snippet in Syncfusion .NET MAUI applications.
+The following software prerequisites must be installed to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extension, as well as for creating, adding snippet in Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI applications.
 
 * [Visual Studio 2022 17.3 or later](https://visualstudio.microsoft.com/downloads/).
 
@@ -25,7 +25,7 @@ The following software prerequisites must be installed to install the Syncfusion
 
 ## Install through the Visual Studio Manage Extensions
 
-The following steps will guide you on how to install the Syncfusion .NET MAUI extensions using **Visual Studio Manage Extensions**.
+The following steps will guide you on how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extensions using **Visual Studio Manage Extensions**.
 
 1. Open Visual Studio 2022.
 
@@ -45,15 +45,15 @@ The following steps will guide you on how to install the Syncfusion .NET MAUI ex
 
 7. After the installation is complete, open the Visual Studio.
 
-8. You can utilize the Syncfusion extensions under the **Extensions** menu in Visual Studio
+8. You can utilize the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions under the **Extensions** menu in Visual Studio
 
      ![SyncfusionMenu](images/MenuExtensions.png)
 
 ## Install from the Visual Studio Marketplace
 
-The following steps illustrate how to download and install the Syncfusion .NET MAUI extension from the Visual Studio Marketplace.
+The following steps illustrate how to download and install the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extension from the Visual Studio Marketplace.
 
-1. Download the Syncfusion .NET MAUI Extensions from the below Visual Studio Marketplace.
+1. Download the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Extensions from the below Visual Studio Marketplace.
 
    [Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.MAUIVSExtension)
 
@@ -65,6 +65,6 @@ The following steps illustrate how to download and install the Syncfusion .NET M
 
 4. Click the **Modify** button.
 
-5. Launch Visual Studio after the installation is complete. You can utilize the Syncfusion extensions under the **Extensions** menu in Visual Studio
+5. Launch Visual Studio after the installation is complete. You can utilize the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions under the **Extensions** menu in Visual Studio
 
      ![SyncfusionMenu](images/MenuExtensions.png)

--- a/Extension/NETMAUI-Extension/Visual-Studio/overview.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio/overview.md
@@ -1,18 +1,18 @@
 ---
 layout: post
-title: Overview of Syncfusion .NET MAUI Extension for Visual Studio | Syncfusion
-description: Learn here all about introduction on Syncfusion .NET MAUI extension for Visual Studio which made integration ease.
+title: Overview of Syncfusion  .NET MAUI Extension for Visual Studio | Syncfusion
+description: Learn here all about introduction on Syncfusion  .NET MAUI extension for Visual Studio which made integration ease.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Overview of .NET MAUI Extension for Visual Studio
 
-The Syncfusion .NET MAUI Extension for Visual Studio simplifies the utilization of Syncfusion .NET MAUI components by configuring the required Syncfusion .NET MAUI NuGet packages. This extension streamlines the development process by providing developers with easy access to the powerful features and functionalities of Syncfusion .NET MAUI components, thereby saving time and effort.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Extension for Visual Studio simplifies the utilization of Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components by configuring the required Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI NuGet packages. This extension streamlines the development process by providing developers with easy access to the powerful features and functionalities of Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components, thereby saving time and effort.
 
 [Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.MAUIVSExtension)
 
-The Syncfusion .NET MAUI extensions provide the following add-ins in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI extensions provide the following add-ins in Visual Studio:
 
-[Project-Template](template-studio):  Creates Syncfusion .NET MAUI applications with the required Syncfusion components and configurations for development.
+[Project-Template](template-studio):  Creates Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI applications with the required Syncfusion<sup style="font-size:70%">&reg;</sup>  components and configurations for development.

--- a/Extension/NETMAUI-Extension/Visual-Studio/template-studio.md
+++ b/Extension/NETMAUI-Extension/Visual-Studio/template-studio.md
@@ -7,27 +7,27 @@ control: Syncfusion Extensions
 documentation: ug
 ---
 
-# Syncfusion .NET MAUI Template Studio
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Template Studio
 
-The .NET MAUI Template Studio is provided by Syncfusion and is used to build the Syncfusion .NET MAUI applications using Syncfusion components. The required Syncfusion components, NuGet references, namespace, and component render code are all used to develop the Syncfusion .NET MAUI applications. The Syncfusion .NET MAUI Template Studio providing a project wizard to simplify the process for you to create an application using Syncfusion components.
+The .NET MAUI Template Studio is provided by Syncfusion<sup style="font-size:70%">&reg;</sup>  and is used to build the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI applications using Syncfusion<sup style="font-size:70%">&reg;</sup>  components. The required Syncfusion<sup style="font-size:70%">&reg;</sup>  components, NuGet references, namespace, and component render code are all used to develop the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI applications. The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Template Studio providing a project wizard to simplify the process for you to create an application using Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 The following steps below will assist you to create your **Syncfusion .NET MAUI Application** through **Visual Studio 2022**:
 
-N> Before use the Syncfusion .NET MAUI Project Template, check whether the Syncfusion .NET MAUI Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
+N> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Project Template, check whether the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Template Studio Extension installed or not in Visual Studio Extension Manager by clicking on the Extensions -> Manage Extensions -> Installed. If this extension not installed, install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
 
 1. Open the Visual Studio 2022.
 
-2. To develop the Syncfusion .NET MAUI application, select one of the following options:
+2. To develop the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application, select one of the following options:
 
      **Option 1**
 
-     Choose **Extension -> Syncfusion -> Essential Studio for .NET MAUI -> Create New Syncfusion Project...** from the **Visual Studio menu**.
+     Choose **Extension -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Essential Studio<sup style="font-size:70%">&reg;</sup>  for .NET MAUI -> Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project...** from the **Visual Studio menu**.
 
      ![CreateMenu](images/MenuProject.png)
 
      **Option 2**
 
-     Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Filtering the application type by **Syncfusion** or typing **Syncfusion** as a keyword in the search option can help you to find the Syncfusion templates for .NET MAUI.
+     Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Filtering the application type by **Syncfusion** or typing **Syncfusion** as a keyword in the search option can help you to find the Syncfusion<sup style="font-size:70%">&reg;</sup>  templates for .NET MAUI.
 
      ![CreateNewWindow](images/ProjectTemplates.png)
 
@@ -35,7 +35,7 @@ N> Before use the Syncfusion .NET MAUI Project Template, check whether the Syncf
 
      ![CreateNewWizard](images/SyncfusionTemplate.png)
 
-4. After launching the Syncfusion .NET MAUI Template Studio, the wizard for configuring the Syncfusion .NET MAUI application will appear. You can add the following Syncfusion .NET MAUI components to the application. Choose the required Syncfusion .NET MAUI components 
+4. After launching the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI Template Studio, the wizard for configuring the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application will appear. You can add the following Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components to the application. Choose the required Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI components 
 
     ![Controls Section](images/ControlsTab.png)
 
@@ -65,10 +65,10 @@ N> Before use the Syncfusion .NET MAUI Project Template, check whether the Syncf
 
      ![Choose required Project Details](images/ProjectDetails.png)
 
-7. Click the **Create** button to create the Syncfusion .NET MAUI application The created Syncfusion .NET MAUI application has the Syncfusion NuGet packages,and the rendering code for the selected Syncfusion components.
+7. Click the **Create** button to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application The created Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application has the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages,and the rendering code for the selected Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
      ![Readme](images/MauiApplication.png)
 
-8. The Syncfusion .NET MAUI application configures with most recent Syncfusion .NET MAUI NuGet packages version, namespaces , and component render code for Syncfusion components.
+8. The Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI application configures with most recent Syncfusion<sup style="font-size:70%">&reg;</sup>  .NET MAUI NuGet packages version, namespaces , and component render code for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
-9. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.
+9. If you installed the trial setup or NuGet packages from nuget.org you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx?_ga=2.11237684.1233358434.1587355730-230058891.1567654773) post for understanding the licensing changes introduced in Essential Studio.

--- a/Extension/Syncfusion-NuGet-Packages/NuGet-Packages.md
+++ b/Extension/Syncfusion-NuGet-Packages/NuGet-Packages.md
@@ -7,11 +7,11 @@ control: NuGet Packages
 documentation: ug
 ---
 
-# Syncfusion NuGet Packages Overview
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages Overview
 
-[NuGet](https://www.nuget.org/) can be used to automatically add files and references to your Visual Studio projects. You can use the Syncfusion NuGet packages without installing the Essential Studio or platform installation to development with the Syncfusion controls. From v16.2.0.46 (2018 Volume 2 Service Pack 1) onwards, all the Syncfusion components are available as NuGet packages at [nuget.org](https://www.nuget.org/profiles/SyncfusionInc). 
+[NuGet](https://www.nuget.org/) can be used to automatically add files and references to your Visual Studio projects. You can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages without installing the Essential Studio<sup style="font-size:70%">&reg;</sup>  or platform installation to development with the Syncfusion<sup style="font-size:70%">&reg;</sup>  controls. From v16.2.0.46 (2018 Volume 2 Service Pack 1) onwards, all the Syncfusion<sup style="font-size:70%">&reg;</sup>  components are available as NuGet packages at [nuget.org](https://www.nuget.org/profiles/SyncfusionInc). 
 
-N> Starting from v17.1.0.32 (2018 Volume 1), Syncfusion will no longer publish NuGet packages at [nuget.syncfusion.com](https://nuget.syncfusion.com/).
+N> Starting from v17.1.0.32 (2018 Volume 1), Syncfusion<sup style="font-size:70%">&reg;</sup>  will no longer publish NuGet packages at [nuget.syncfusion.com](https://nuget.syncfusion.com/).
 
 ## Installing NuGet Packages
 
@@ -29,15 +29,15 @@ The NuGet Package Manager can be used to search and install NuGet packages in th
 
      ![NuGet package manager dialog window](NuGet_Packages_Images/img7.png)             
 
-3.	The Syncfusion NuGet Packages are listed the available package in the source feed URL. Search and install the required packages in your application, by clicking **Install** button.
+3.	The Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages are listed the available package in the source feed URL. Search and install the required packages in your application, by clicking **Install** button.
 
 
-N> The Syncfusion NuGet packages are published in public [NuGet.org](https://www.nuget.org/) from v16.2.0.46. So, If you need to Install earlier version of 16.2.0.46 Syncfusion NuGet packages, [configure Syncfusion private feed URL](https://help.syncfusion.com/extension/syncfusion-nuget-packages/nuget-packages#syncfusion-nuget-feed-url-configuration).
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages are published in public [NuGet.org](https://www.nuget.org/) from v16.2.0.46. So, If you need to Install earlier version of 16.2.0.46 Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, [configure Syncfusion<sup style="font-size:70%">&reg;</sup>  private feed URL](https://help.syncfusion.com/extension/syncfusion-nuget-packages/nuget-packages#syncfusion-nuget-feed-url-configuration).
 
 
 ### Using Package Manager Console
 
-To reference the Syncfusion component using the Package Manager Console as NuGet packages, follow the below steps. 
+To reference the Syncfusion<sup style="font-size:70%">&reg;</sup>  component using the Package Manager Console as NuGet packages, follow the below steps. 
 
 1.	On the **Tools** menu, select **NuGet Package Manager**, and then **Package Manager Console**. 
 
@@ -73,7 +73,7 @@ Add packages can be used to search and install NuGet packages to the Visual Stud
 
     ![Add packages dialog](NuGet_Packages_Images/img9.png)  
 
-3.	The Syncfusion NuGet Packages available in the package source location will be listed. Search and install the required packages in your application, by clicking **Add Package** button.
+3.	The Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages available in the package source location will be listed. Search and install the required packages in your application, by clicking **Add Package** button.
 
 ## Managing NuGet package using NuGet CLI
 
@@ -115,7 +115,7 @@ The NuGet Command Line Interface (CLI), nuget.exe, provides the full extent of N
     mono nuget.exe install “C:\Users\SyncfusionApplication\package.config”
     ~~~
 
-N> If you need to Install earlier version of 16.2.0.46 Syncfusion NuGet packages, [configure Syncfusion private feed URL](https://help.syncfusion.com/extension/syncfusion-nuget-packages/nuget-packages#syncfusion-nuget-feed-url-configuration).
+N> If you need to Install earlier version of 16.2.0.46 Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, [configure Syncfusion<sup style="font-size:70%">&reg;</sup>  private feed URL](https://help.syncfusion.com/extension/syncfusion-nuget-packages/nuget-packages#syncfusion-nuget-feed-url-configuration).
 
 ## Managing NuGet package using Dotnet CLI
 
@@ -149,13 +149,13 @@ The NuGet Command Line Interface (CLI), Dotnet.exe, provides the full extent of 
 
 ## Managing NuGet package for Visual Studio online application
 
-The following steps help you to configure and restore the Syncfusion NuGet packages in Visual Studio online application.
+The following steps help you to configure and restore the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in Visual Studio online application.
 
 ### Configure NuGet feed URL 
 
 1.  Create and add the NuGet.config file in your Visual Studio online application location. By default, the NuGet.org feed link can be added in the NuGet.config file. 
 
-    N> If you need to Install v16.2.0.46 before Syncfusion NuGet packages, add the required Syncfusion platform NuGet feed links in the NuGet.config file. You can get the Syncfusion NuGet package feed link by clicking the **Copy URL** label from the required platform provided in the following link:
+    N> If you need to Install v16.2.0.46 before Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  platform NuGet feed links in the NuGet.config file. You can get the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package feed link by clicking the **Copy URL** label from the required platform provided in the following link:
     <https://nuget.syncfusion.com/>
      
     ![Sample project configuration page in Visual Studio Online Application](NuGet-VisualStudioonline_images/NuGet-VisualStudioonline-img1.png)
@@ -209,7 +209,7 @@ N> To update all the projects from solution, use update option in the solution l
 
 ### Using Package Manger Console
 
-To update the installed Syncfusion NuGet packages using the Package Manager Console, follow the below steps. 
+To update the installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages using the Package Manager Console, follow the below steps. 
 
 1.	On the **Tools** menu, select **NuGet Package Manager**, and then **Package Manager Console.** 
 
@@ -229,7 +229,7 @@ To update the installed Syncfusion NuGet packages using the Package Manager Cons
     **For example:**
 
     ~~~
-    #Update specified Syncfusion NuGet package 
+    #Update specified Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package 
     Update-Package Syncfusion.EJ.AspNet.Core
 
     #Update specified package in specified project 
@@ -248,7 +248,7 @@ Using the NuGet CLI, all the NuGet packages in the project can be updated to the
     nuget update -self
     ~~~
 
-2.	Open the downloaded executable location in the command window. Run the following “update commands” to update the Syncfusion ASP.NET Core NuGet packages.
+2.	Open the downloaded executable location in the command window. Run the following “update commands” to update the Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core NuGet packages.
 
     ~~~ 
     #update all NuGet packages from config file
@@ -269,21 +269,21 @@ Using the NuGet CLI, all the NuGet packages in the project can be updated to the
 
     N> Update command is not working as expected in Mono (Mac and Linux) and projects using PackageReference format.
    
-## Syncfusion NuGet feed URL Configuration
+## Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed URL Configuration
 
-### Get the Syncfusion NuGet feed URL 
+### Get the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed URL 
 
-You should get the private Syncfusion NuGet feed URL to install or upgrade the Syncfusion NuGet packages. To get the URL from Syncfusion website use the following steps:
+You should get the private Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed URL to install or upgrade the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages. To get the URL from Syncfusion<sup style="font-size:70%">&reg;</sup>  website use the following steps:
 
 1. Navigate to [nuget.syncfusion.com](https://nuget.syncfusion.com/), and select the required platform tab.     
 
-2. Click the Copy URL label under required platform to copy the Syncfusion required platform NuGet feed to clipboard.
+2. Click the Copy URL label under required platform to copy the Syncfusion<sup style="font-size:70%">&reg;</sup>  required platform NuGet feed to clipboard.
 
     ![Syncfusion Essential JS 2 ASP.NET Core NuGet feed URL](NuGet_Packages_Images/img1.png)
 
-3. Now, use this NuGet feed URL to access the Syncfusion NuGet Packages in Visual Studio. 
+3. Now, use this NuGet feed URL to access the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages in Visual Studio. 
 
-### Add the Syncfusion NuGet feed URL
+### Add the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed URL
 
 #### Windows
 
@@ -293,17 +293,17 @@ You should get the private Syncfusion NuGet feed URL to install or upgrade the S
 
 3.	Expand the **NuGet Package Manager** and select **Package Sources**.
 
-4.	Click the **Add** button (green plus), and enter the ‘Package Name’ and ‘Package Source URL’ of the Syncfusion NuGet packages.
+4.	Click the **Add** button (green plus), and enter the ‘Package Name’ and ‘Package Source URL’ of the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages.
     
     **Name:** Name of the package source.
     
-    **Source:** Syncfusion NuGet Feed URL.      
+    **Source:** Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Feed URL.      
 
-    For example, Name: Syncfusion AspNet Core Packages, Source: [https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore](https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore).
+    For example, Name: Syncfusion<sup style="font-size:70%">&reg;</sup>  AspNet Core Packages, Source: [https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore](https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore).
 
 5.	Click the **Update** button to add the name and source details to package sources. 
 
-    ![NuGet Package Manager dialog with Syncfusion Essential JS 2 NuGet feed URL for reference](NuGet_Packages_Images/img2.png)
+    ![NuGet Package Manager dialog with Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential JS 2 NuGet feed URL for reference](NuGet_Packages_Images/img2.png)
 
 #### macOS 
 
@@ -321,11 +321,11 @@ You should get the private Syncfusion NuGet feed URL to install or upgrade the S
    
     **Name:** Name of the package source.
     
-    **Source:** Syncfusion NuGet Feed URL.      
+    **Source:** Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Feed URL.      
 
-    For example, Name: Syncfusion ASP.NET Core Packages, Source: [https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore](https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore).
+    For example, Name: Syncfusion<sup style="font-size:70%">&reg;</sup>  ASP.NET Core Packages, Source: [https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore](https://nuget.syncfusion.com/nuget_aspnetcore/nuget/getsyncfusionpackages/aspnetcore).
     
-	![Add Package Source dialog to add Syncfusion NuGet feed](NuGet_Packages_Images/img5.png)
+	![Add Package Source dialog to add Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed](NuGet_Packages_Images/img5.png)
  
 5.	Now, click **Add Source** and then click **OK**.
 
@@ -339,7 +339,7 @@ You should get the private Syncfusion NuGet feed URL to install or upgrade the S
     nuget update -self
     ~~~
 
-2.	Open the downloaded executable location in the command window, and run the following commands to configure the Syncfusion NuGet packages: 
+2.	Open the downloaded executable location in the command window, and run the following commands to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages: 
 
     ~~~
     #Add specified package source in NuGet.config file for Windows platform

--- a/Extension/Syncfusion-NuGet-Packages/NuGet-Uninstallation-process.md
+++ b/Extension/Syncfusion-NuGet-Packages/NuGet-Uninstallation-process.md
@@ -3,7 +3,7 @@ layout: post
 title: NuGet Uninstallation process | Extension | Syncfusion
 description: Describing the nuget uninstallation process using NuGet Package Manager dialog and Package Manager console window
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -12,33 +12,33 @@ documentation: ug
 
 ## NuGet Uninstallation by using NuGet Package Manager
 
-You can uninstall already installed Syncfusion NuGet packages from project using the following steps via NuGet Package Manager dialog.
+You can uninstall already installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages from project using the following steps via NuGet Package Manager dialog.
 
 1. Right-click on Project and select **Manage NuGet Packages** option. 
 
    ![Installed packages details in NuGet Package Manager dialog](NuGet-Uninstallation_images/NuGet-Uninstallation-img2.png)
    
-2. Select the **Installed** tab from NuGet Package Manager dialog and you can see the installed Syncfusion NuGet packages list by giving the Syncfusion keyword in search.
+2. Select the **Installed** tab from NuGet Package Manager dialog and you can see the installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages list by giving the Syncfusion<sup style="font-size:70%">&reg;</sup>  keyword in search.
 
    ![Installed packages details in NuGet Package Manager dialog](NuGet-Uninstallation_images/NuGet-Uninstallation-img3.png)
 
-3. Uninstall the Syncfusion NuGet packages which are not required for the project. 
+3. Uninstall the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages which are not required for the project. 
 
    ![Installed packages details in NuGet Package Manager dialog](NuGet-Uninstallation_images/NuGet-Uninstallation-img1.png)
 
 N> You cannot uninstall the dependent package because of the package being referred in other NuGet Packages. It removes Project Reference and package from the project location.
 
-4. If you don't want to uninstall the dependent NuGet packages when uninstall the Syncfusion NuGet packages, you can select the **Ignore Dependencies** option to ignore the uninstallation for dependent packages.
+4. If you don't want to uninstall the dependent NuGet packages when uninstall the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages, you can select the **Ignore Dependencies** option to ignore the uninstallation for dependent packages.
 
    ![Installed packages details in NuGet Package Manager dialog](NuGet-Uninstallation_images/NuGet-Uninstallation-img4.png)
 
 ## NuGet Uninstallation by using Package Manager Console
 
-You can uninstall already installed Syncfusion NuGet packages from project using the following steps via Package Manager Console window.
+You can uninstall already installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages from project using the following steps via Package Manager Console window.
 
 1. Select the **Tools-> NuGet Package Manager-> Package Manager Console**.
 
-2. Run the following command to uninstall the specified Syncfusion NuGet Package with the package name. 
+2. Run the following command to uninstall the specified Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package with the package name. 
 
    uninstall-package {package name} –RemoveDependencies
 

--- a/Extension/Syncfusion-NuGet-Packages/Register-the-Syncfusion-License-key.md
+++ b/Extension/Syncfusion-NuGet-Packages/Register-the-Syncfusion-License-key.md
@@ -1,40 +1,40 @@
 ---
 layout: post
-title: Syncfusion NuGet Package Licensing | Extension | Syncfusion
-description: Syncfusion provides the license per developer licensing model. Each license is for a single named user not for any servers.
+title: Syncfusion  NuGet Package Licensing | Extension | Syncfusion
+description: Syncfusion  provides the license per developer licensing model. Each license is for a single named user not for any servers.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion NuGet Package Licensing 
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Licensing 
 
-Syncfusion provides the license per developer licensing model. Each license is for a single named user. Also, Syncfusion doesn’t require separate license for any servers. So, if you have license for each developer it is not necessary to do license key registration to use the Syncfusion NuGet packages.
+Syncfusion provides the license per developer licensing model. Each license is for a single named user. Also, Syncfusion<sup style="font-size:70%">&reg;</sup>  doesn’t require separate license for any servers. So, if you have license for each developer it is not necessary to do license key registration to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages.
 
-N> Syncfusion removed the runtime and design time license key from v13.2.0.29 to v16.2.0.41. So, no need to register the license key either in application or system if you are using the Essential Studio from v13.2.0.29 to v16.2.0.41 versions.
+N> Syncfusion<sup style="font-size:70%">&reg;</sup>  removed the runtime and design time license key from v13.2.0.29 to v16.2.0.41. So, no need to register the license key either in application or system if you are using the Essential Studio<sup style="font-size:70%">&reg;</sup>  from v13.2.0.29 to v16.2.0.41 versions.
 
-N> Syncfusion removed the runtime and design time license key from v13.2.0.29 to v16.2.0.41. So, no need to register the license key either in application or system if you are using the Essential Studio from v13.2.0.29 to v16.2.0.41 versions.
+N> Syncfusion<sup style="font-size:70%">&reg;</sup>  removed the runtime and design time license key from v13.2.0.29 to v16.2.0.41. So, no need to register the license key either in application or system if you are using the Essential Studio<sup style="font-size:70%">&reg;</sup>  from v13.2.0.29 to v16.2.0.41 versions.
 
-## How to register Syncfusion license on or after to 16.2.0.41 version
+## How to register Syncfusion<sup style="font-size:70%">&reg;</sup>  license on or after to 16.2.0.41 version
 
-We have introduced a new licensing system starting with version 16.2.0.41 release of Essential Studio. These changes apply to all evaluators and only to paid customers who use NuGet packages from [nuget.org](https://www.nuget.org/). Starting with v16.2.0.41, if you reference Syncfusion assemblies from evaluation installer or from the NuGet feed, you also have to include a license key in your projects. Please note that this license key is different from the installer unlock key that you might have used in the past, and needs to be separately generated from Syncfusion website. The following steps guide you as to how to register the Syncfusion license.
+We have introduced a new licensing system starting with version 16.2.0.41 release of Essential Studio<sup style="font-size:70%">&reg;</sup>. These changes apply to all evaluators and only to paid customers who use NuGet packages from [nuget.org](https://www.nuget.org/). Starting with v16.2.0.41, if you reference Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies from evaluation installer or from the NuGet feed, you also have to include a license key in your projects. Please note that this license key is different from the installer unlock key that you might have used in the past, and needs to be separately generated from Syncfusion<sup style="font-size:70%">&reg;</sup>  website. The following steps guide you as to how to register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license.
 
-1. Generate the Syncfusion License key by follow the steps from the [page](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key)
-2. Register the Syncfusion license key in corresponding application by follow the steps from the [page](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-register-the-syncfusion-license-key)
+1. Generate the Syncfusion<sup style="font-size:70%">&reg;</sup>  License key by follow the steps from the [page](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key)
+2. Register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key in corresponding application by follow the steps from the [page](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-register-the-syncfusion-license-key)
 
-   > Before register the Syncfusion license key, ensure that all referenced Syncfusion NuGet packages are all on the same version as license key version, because our license keys are version and platform-specific.
+   > Before register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key, ensure that all referenced Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages are all on the same version as license key version, because our license keys are version and platform-specific.
 
-## How to register Syncfusion license prior to 13.2.0.29 version
+## How to register Syncfusion<sup style="font-size:70%">&reg;</sup>  license prior to 13.2.0.29 version
 
-While using Syncfusion NuGet package of version that is **prior to 13.2.0.29**, you need to register for the Syncfusion license for development purpose. The following steps guide you as to how to register for the Syncfusion license.
+While using Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package of version that is **prior to 13.2.0.29**, you need to register for the Syncfusion<sup style="font-size:70%">&reg;</sup>  license for development purpose. The following steps guide you as to how to register for the Syncfusion<sup style="font-size:70%">&reg;</sup>  license.
 
 1. Download the [Syncfusion License](http://files2.syncfusion.com/Installs/Support/KB/RegisterProductkeyinBuildMachine.zip) Register tool and extract the file. 
 2. Open the Command Prompt with administrator privileges.
-3. Navigate to the root location of the extracted downloaded, Syncfusion license.
+3. Navigate to the root location of the extracted downloaded, Syncfusion<sup style="font-size:70%">&reg;</sup>  license.
 4. Run the following command to register the Unlock key.
 
    Synckeynoui.exe “Unlock key”
 
-   N> You should provide the unlock key which is started with "@" and ended with "=" as a parameter for this Syncfusion License tool.
+   N> You should provide the unlock key which is started with "@" and ended with "=" as a parameter for this Syncfusion<sup style="font-size:70%">&reg;</sup>  License tool.
 
-   ![Command for register the Syncfusion Unlock key](Register-the-Syncfusion-License-key_images/Register-the-Syncfusion-License-key-img1.png)
+   ![Command for register the Syncfusion  Unlock key](Register-the-Syncfusion-License-key_images/Register-the-Syncfusion-License-key-img1.png)

--- a/Extension/Syncfusion-NuGet-Packages/Syncfusion-NuGet-Manager.md
+++ b/Extension/Syncfusion-NuGet-Packages/Syncfusion-NuGet-Manager.md
@@ -1,67 +1,67 @@
 ---
 layout: post
-title: Syncfusion NuGet Manager | Extension | Syncfusion
-description: Syncfusion NuGet Package Manager is the utility that allows you to add, remove and update the Syncfusion NuGet sources (available platforms) to NuGet Package Manager
+title: Syncfusion  NuGet Manager | Extension | Syncfusion
+description: Syncfusion  NuGet Package Manager is the utility that allows you to add, remove and update the Syncfusion  NuGet sources (available platforms) to NuGet Package Manager
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion NuGet Package Manager
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Manager
 
 ## Overview
 
-Syncfusion NuGet Package Manager is the utility that allows you to add, remove and update the Syncfusion NuGet sources (available platforms) to NuGet Package Manager. Download the Syncfusion NuGet Manager utility from [here](http://www.syncfusion.com/downloads/support/directtrac/general/ze/SyncfusionNuGetManager-2143130196).
+Syncfusion NuGet Package Manager is the utility that allows you to add, remove and update the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet sources (available platforms) to NuGet Package Manager. Download the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager utility from [here](http://www.syncfusion.com/downloads/support/directtrac/general/ze/SyncfusionNuGetManager-2143130196).
 
-## Add Syncfusion NuGet Package sources 
+## Add Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package sources 
 
-The following steps directs you to add the Syncfusion NuGet Package sources from Syncfusion NuGet Manager. 
+The following steps directs you to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package sources from Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager. 
 
-1. Run the SyncfusionNuGetManager.exe from Syncfusion NuGet Manager extracted location. 
+1. Run the SyncfusionNuGetManager.exe from Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager extracted location. 
 
    ![Syncfusion NuGet Manager extracted location](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img1.png)
 
-2. Syncfusion NuGet Manager Window will be opened.
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager Window will be opened.
 
    ![Syncfusion NuGet Manager main window](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img2.png)
 
 3. Select the required platforms needed to be configured from “Select platforms to add” (Left side of the window) column and click Add>> button.
 
-   ![Selected platforms NuGet feed configure option in Syncfusion NuGet Manager](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img3.png)
+   ![Selected platforms NuGet feed configure option in Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img3.png)
 
-4. Now selected platforms will be added under “Selected platforms to remove” (Right side of the window) column. Click “Configure” button to add the required Syncfusion Package sources to NuGet Package Manager.
+4. Now selected platforms will be added under “Selected platforms to remove” (Right side of the window) column. Click “Configure” button to add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Package sources to NuGet Package Manager.
 
-   ![Selected platforms NuGet feed remove option in Syncfusion NuGet Manager](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img4.png)
+   ![Selected platforms NuGet feed remove option in Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img4.png)
 
-5. Once Syncfusion NuGet Manager added the Syncfusion NuGet sources, the changes will be reflected in package sources of your Visual Studio. 
+5. Once Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager added the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet sources, the changes will be reflected in package sources of your Visual Studio. 
 
-   ![NuGet package manager dialog with Syncfusion NuGet feeds](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img5.png)
+   ![NuGet package manager dialog with Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feeds](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img5.png)
 
-## Remove Syncfusion NuGet Package sources 
+## Remove Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package sources 
 
-1. If any configured Syncfusion NuGet Package sources are no longer required, Select the unwanted platforms from “Select platforms to remove” (Right side of the window) column and click <<Remove button. 
+1. If any configured Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package sources are no longer required, Select the unwanted platforms from “Select platforms to remove” (Right side of the window) column and click <<Remove button. 
 
-   ![Remove option in Syncfusion NuGet Manager to remove the already configured Syncfusion NuGet feed](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img6.png)   
+   ![Remove option in Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager to remove the already configured Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img6.png)   
 
-2. Now selected platforms will be added under “Selected platforms to add” (Left side of the window) column. Click “Configure” button to remove the required Syncfusion Package sources to NuGet Package Manager.
+2. Now selected platforms will be added under “Selected platforms to add” (Left side of the window) column. Click “Configure” button to remove the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Package sources to NuGet Package Manager.
 
-3. Once Syncfusion NuGet Manager removed the Syncfusion NuGet sources, the changes will be reflected in NuGet.config file of your machine and updated the same in available package sources of your Visual Studio. 
+3. Once Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager removed the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet sources, the changes will be reflected in NuGet.config file of your machine and updated the same in available package sources of your Visual Studio. 
 
-## Syncfusion NuGet Manager command line
+## Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager command line
 
-The following steps directs you to use the Syncfusion NuGet Manager from command line.
+The following steps directs you to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager from command line.
 
 1. Open Windows Command Prompt in Administrator Mode.
 
-2. Navigate to SyncfusionNuGetManager.exe from Syncfusion NuGet Manager extracted location.  
+2. Navigate to SyncfusionNuGetManager.exe from Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager extracted location.  
 
-3. Run SyncfusionNuGetManager.exe with required platforms arguments. Refer the below table for platform as arguments to configure the Syncfusion NuGet Packages sources. 
+3. Run SyncfusionNuGetManager.exe with required platforms arguments. Refer the below table for platform as arguments to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages sources. 
 
-   ![Command to add Syncfusion NuGet feed](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img8.jpeg)
+   ![Command to add Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img8.jpeg)
 
 **Add**
 
-To add the Syncfusion NuGet feed link with below command.
+To add the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet feed link with below command.
 
 SyncfusionNuGetManager.exe Add [platform key]
 
@@ -77,7 +77,7 @@ Example:SyncfusionNuGetManager.exe Update JavaScript “D:\Syncfusion\JavaScript
 
 **Remove**
 
-To remove the configured Syncfusion NuGet by below command.
+To remove the configured Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet by below command.
 
 SyncfusionNuGetManager.exe Remove [platform  key] [local NuGet Location]
 
@@ -150,7 +150,7 @@ Here the list of keyword for platform keys to access.
  </tbody>
 </table>
 
-4. Once Syncfusion NuGet Manager removed the Syncfusion NuGet sources, the changes will be reflected in NuGet.config file of your machine and updated the same in available package sources of your Visual Studio. 
+4. Once Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Manager removed the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet sources, the changes will be reflected in NuGet.config file of your machine and updated the same in available package sources of your Visual Studio. 
 
-   ![NuGet package manager dialog with Syncfusion NuGet feeds](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img5.png)
+   ![NuGet package manager dialog with Syncfusion  NuGet feeds](SyncfusionNuGetManager_images/SyncfusionNuGetManager-img5.png)
 

--- a/Extension/Syncfusion-Reference-Manager/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger.md
+++ b/Extension/Syncfusion-Reference-Manager/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger.md
@@ -3,28 +3,28 @@ layout: post
 title: Add Reference Manger | Extension | Syncfusion
 description: Learn here all about how to add a syncfusion Essential  references via reference manger in Extenion, it's elements and more.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Add a Syncfusion References via Syncfusion Reference Manger
+# Add a Syncfusion<sup style="font-size:70%">&reg;</sup>  References via Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manger
 
-The Add-In launches a pop-up window that contains the list of Syncfusion controls that are loaded, based on the platform of the project. If it is a WPF project, all the Syncfusion WPF controls are loaded.
+The Add-In launches a pop-up window that contains the list of Syncfusion<sup style="font-size:70%">&reg;</sup>  controls that are loaded, based on the platform of the project. If it is a WPF project, all the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF controls are loaded.
 
 To add the assemblies:
 
-1. Select the Syncfusion Reference Manager either in the WPF, Windows Forms/Console/Class Library or Silverlight Project.
+1. Select the Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager either in the WPF, Windows Forms/Console/Class Library or Silverlight Project.
 2. The Syncfusion Reference Manager dialog is displayed as shown in the following screenshot.
 
    ![Syncfusion Reference Manger Wizard](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img1.png)
 
-3. If launched the Syncfusion Reference Manager from Console/Class Library project, Platform selection option will be appeared as option in Syncfusion Reference Manager. Choose the required platform based on your need. 
+3. If launched the Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager from Console/Class Library project, Platform selection option will be appeared as option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager. Choose the required platform based on your need. 
 
-    ![Platform selection option in Syncfusion Reference Manger](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img6.png)
+    ![Platform selection option in Syncfusion  Reference Manger](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img6.png)
 
-    N> Platform selection option will be appeared only if Essential Studio for Enterprise Edition with the platforms WPF and Windows Forms has been installed or both Essential Studio for WPF and Essential Studio for Windows Forms has been installed.
+    N> Platform selection option will be appeared only if Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platforms WPF and Windows Forms has been installed or both Essential Studio<sup style="font-size:70%">&reg;</sup>  for WPF and Essential Studio<sup style="font-size:70%">&reg;</sup>  for Windows Forms has been installed.
 
-4. If launched the Syncfusion Reference Manager from WPF project or select the WPF platform from platform selection option, **Themes** option will be appeared as option in Syncfusion Reference Manger. Choose the required themes based on your need. Refer the below link to know more about built in themes and its available assemblies.
+4. If launched the Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager from WPF project or select the WPF platform from platform selection option, **Themes** option will be appeared as option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manger. Choose the required themes based on your need. Refer the below link to know more about built in themes and its available assemblies.
 
     [https://help.syncfusion.com/wpf/themes/skin-manager](https://help.syncfusion.com/wpf/themes/skin-manager)
 
@@ -32,20 +32,20 @@ To add the assemblies:
 
     N> Themes option will be enabled only if selected SfSkinManager supported controls.
 
-    ![Tooltip information for Syncfusion Reference Manager themes option](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img5.png)
+    ![Tooltip information for Syncfusion  Reference Manager themes option](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img5.png)
 
 5. Reference assemblies
-   * You can add Syncfusion assemblies from NuGet packages, the build installed location, or by using the GAC location. This option determines the location of the assemblies that are referenced in the project.
+   * You can add Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies from NuGet packages, the build installed location, or by using the GAC location. This option determines the location of the assemblies that are referenced in the project.
 
-   N> The installed location and GAC option will be available only when the Syncfusion Essential Studio setup has been installed.
+   N> The installed location and GAC option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  setup has been installed.
 
-   ![Options for assembly location in Syncfusion Reference Manager](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img8.png)
+   ![Options for assembly location in Syncfusion  Reference Manager](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img8.png)
 
     N> The GAC option will not be available if you have selected a .NET 7.0 or .NET 6.0 application in Visual Studio 2022.
 
-   * Select the Syncfusion Essential Studio versions that were previously installed on your machine.This option determines the assembly version that is referenced in the project.
+   * Select the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  versions that were previously installed on your machine.This option determines the assembly version that is referenced in the project.
 
-   ![Versions for assemblies in Syncfusion Reference Manager](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img9.png)
+   ![Versions for assemblies in Syncfusion  Reference Manager](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img9.png)
 
    * Choose the required controls that you want include in project
 6. Click Done to add the required assemblies for the selected controls into the project. The   following screenshot shows the list of required assemblies for 
@@ -53,15 +53,15 @@ To add the assemblies:
 
    ![Syncfusion Reference Manager new assemblies add information dialog](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img2.png)
 
-7. Click OK. The listed Syncfusion assemblies are added to project. Then it notifies “Syncfusion assemblies have been added successfully” in Visual Studio status bar.
+7. Click OK. The listed Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies are added to project. Then it notifies “Syncfusion assemblies have been added successfully” in Visual Studio status bar.
 
    ![Syncfusion Reference Manager success status in Visual Studio status bar](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img3.png)
 
-8. Then, Syncfusion licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+8. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-   ![Syncfusion license registration required information dialog in Syncfusion Reference Manager](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img7.png)
+   ![Syncfusion license registration required information dialog in Syncfusion  Reference Manager](Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger_images/Add-a-Syncfusion-References-via-Syncfusion-Reference-Manger-img7.png)
 
-N> We are providing Syncfusion Reference Manager support for specific framework which is shipped (assemblies) in our Syncfusion Essential Studio setup. So, if we try to add Syncfusion assemblies in project and project framework is not supported with selected Syncfusion version assemblies, the dialog will be appeared along with **“Current build v{version} is not supported this framework v{Framework Version}”** message.
+N> We are providing Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager support for specific framework which is shipped (assemblies) in our Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  setup. So, if we try to add Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in project and project framework is not supported with selected Syncfusion<sup style="font-size:70%">&reg;</sup>  version assemblies, the dialog will be appeared along with **“Current build v{version} is not supported this framework v{Framework Version}”** message.
 
 
 

--- a/Extension/Syncfusion-Reference-Manager/Configure-Syncfusion-assemblies-in-Visual-Studio-project.md
+++ b/Extension/Syncfusion-Reference-Manager/Configure-Syncfusion-assemblies-in-Visual-Studio-project.md
@@ -3,22 +3,22 @@ layout: post
 title: Reference Manager | Extension | Syncfusion
 description: configure syncfusion assemblies in visual studio project
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Configure Syncfusion assemblies in Visual Studio project
+# Configure Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in Visual Studio project
 
-To open Syncfusion Reference Manager Wizard, follow either one of the options below:
+To open Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager Wizard, follow either one of the options below:
 **Option 1:**  
-Click **Syncfusion Menu** and choose **Essential Studio for WinForms/WPF > Add References…** or any other Form in **Visual Studio**.
+Click **Syncfusion<sup style="font-size:70%">&reg;</sup> Menu** and choose **Essential Studio<sup style="font-size:70%">&reg;</sup> for WinForms/WPF > Add References…** or any other Form in **Visual Studio**.
 
-![Syncfusion Reference Manager via Syncfusion Menu](Configure-Syncfusion-assemblies-in-Visual-Studio-project_images/Syncfusion_Menu_AddReference.png)
+![Syncfusion Reference Manager via Syncfusion  Menu](Configure-Syncfusion-assemblies-in-Visual-Studio-project_images/Syncfusion_Menu_AddReference.png)
 
-N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
 **Option 2:**  
-Right-click the selected project file from Solution Explorer, then select **Syncfusion Reference Manager…** from **Context Menu**. The following screenshot shows this option in Visual Studio.   
+Right-click the selected project file from Solution Explorer, then select **Syncfusion<sup style="font-size:70%">&reg;</sup> Reference Manager…** from **Context Menu**. The following screenshot shows this option in Visual Studio.   
 
 
 

--- a/Extension/Syncfusion-Reference-Manager/Migrate-the-Syncfusion-assemblies.md
+++ b/Extension/Syncfusion-Reference-Manager/Migrate-the-Syncfusion-assemblies.md
@@ -1,21 +1,21 @@
 ---
 layout: post
-title: Migrate the Syncfusion assemblies | Extension | Syncfusion
-description: The Syncfusion Reference Manager can migrate the Syncfusion assemblies to selected version of Syncfusion assemblies when you want to migrate from one version to another version, the Syncfusion references in the project
+title: Migrate the Syncfusion  assemblies | Extension | Syncfusion
+description: The Syncfusion  Reference Manager can migrate the Syncfusion  assemblies to selected version of Syncfusion  assemblies when you want to migrate from one version to another version, the Syncfusion  references in the project
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Migrate the Syncfusion assemblies
+# Migrate the Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies
 
-The Syncfusion Reference Manager can migrate the Syncfusion assemblies to selected version of Syncfusion assemblies when you want to migrate from one version to another version, the Syncfusion references in the project.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager can migrate the Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies to selected version of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies when you want to migrate from one version to another version, the Syncfusion<sup style="font-size:70%">&reg;</sup>  references in the project.
 
-To migrate the Syncfusion assemblies,
+To migrate the Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies,
 
-1. Open the project you would like to migrate with another version of Syncfusion assemblies.
+1. Open the project you would like to migrate with another version of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies.
 2. Select the option Syncfusion Reference Manager in the WPF or Windows Forms or Silverlight Project.
-3. The dialog Syncfusion Reference Manager is opened. Then choose the required Syncfusion Essential Studio version to migrate the project. Refer the following
+3. The dialog Syncfusion Reference Manager is opened. Then choose the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  version to migrate the project. Refer the following
    screenshots for more information.
 
    ![Syncfusion Reference Manager version selection option](Migrate-the-Syncfusion-assemblies_images/Migrate-the-Syncfusion-assemblies-img1.png)
@@ -30,7 +30,7 @@ To migrate the Syncfusion assemblies,
 
 
 6. The option Backup Project copies the project into the Backup folder in the same project location before migration.
-7. Then click OK. The project is migrated to the selected versions of the Syncfusion assembly reference.
+7. Then click OK. The project is migrated to the selected versions of the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference.
 
 
 

--- a/Extension/Syncfusion-Reference-Manager/Overview.md
+++ b/Extension/Syncfusion-Reference-Manager/Overview.md
@@ -1,17 +1,17 @@
 ---
 layout: post
-title: Syncfusion Reference Manager | Extension | Syncfusion
-description: Learn here all about adding the required Syncfusion assembly to Windows project reference based on the selected control(s).
+title: Syncfusion  Reference Manager | Extension | Syncfusion
+description: Learn here all about adding the required Syncfusion  assembly to Windows project reference based on the selected control(s).
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
 ---
 
-# Syncfusion Reference Manager
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager
 
-Syncfusion Reference Manager is the Visual Studio Add-In for WPF, Windows Forms and Silverlight platforms. It adds the Syncfusion assembly reference to the project, either from the GAC location or from Essential Studio installed location or from NuGet packages. It can also migrate the projects that contain the old versions of the Syncfusion assembly reference to newer or specific versions of the Syncfusion assembly reference. It supports Microsoft Visual Studio 2010 or higher. This Visual Studio extension is included from Essential Studio 2013 Volume 3 release.
+Syncfusion Reference Manager is the Visual Studio Add-In for WPF, Windows Forms and Silverlight platforms. It adds the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference to the project, either from the GAC location or from Essential Studio<sup style="font-size:70%">&reg;</sup>  installed location or from NuGet packages. It can also migrate the projects that contain the old versions of the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference to newer or specific versions of the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference. It supports Microsoft Visual Studio 2010 or higher. This Visual Studio extension is included from Essential Studio<sup style="font-size:70%">&reg;</sup>  2013 Volume 3 release.
 
-N> This Reference Manager can be applied to a project for Syncfusion assembly versions 10.4.0.71 and later.
+N> This Reference Manager can be applied to a project for Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly versions 10.4.0.71 and later.
 
 
 

--- a/Extension/Syncfusion-Troubleshooter/Overview.md
+++ b/Extension/Syncfusion-Troubleshooter/Overview.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: Syncfusion Troubleshooter | Extension | Syncfusion
-description: The Syncfusion Troubleshooter is a Visual Studio extension to troubleshoot the configuration issues of Syncfusion controls in projects. If Visual Studio project has any configuration issue with in Syncfusion control like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly, the Syncfusion Troubleshooter will investigate these type of problem and fix them
+title: Syncfusion  Troubleshooter | Extension | Syncfusion
+description: The Syncfusion  Troubleshooter is a Visual Studio extension to troubleshoot the configuration issues of Syncfusion  controls in projects. If Visual Studio project has any configuration issue with in Syncfusion  control like, wrong Framework Syncfusion  assembly added to the project or missing any Syncfusion  dependent assembly of a referred assembly, the Syncfusion Troubleshooter will investigate these type of problem and fix them
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
 ---
 
-# Syncfusion Troubleshooter
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter
 
-The Syncfusion Troubleshooter is a Visual Studio extension to troubleshoot the configuration issues of Syncfusion controls in projects. It supports Microsoft Visual Studio 2010 or higher. If Visual Studio project has any configuration issue with in Syncfusion control like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly, the Syncfusion Troubleshooter will investigate these type of problem and fix them. The Syncfusion Troubleshooter available from Syncfusion Essential Studio v14.3.0.49. Currently the Syncfusion Troubleshooter is available for the following project types.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter is a Visual Studio extension to troubleshoot the configuration issues of Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in projects. It supports Microsoft Visual Studio 2010 or higher. If Visual Studio project has any configuration issue with in Syncfusion<sup style="font-size:70%">&reg;</sup>  control like, wrong Framework Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly added to the project or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will investigate these type of problem and fix them. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter available from Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  v14.3.0.49. Currently the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter is available for the following project types.
 
 * Windows Forms Application.
 
@@ -23,18 +23,18 @@ The Syncfusion Troubleshooter is a Visual Studio extension to troubleshoot the c
 
 * Universal Windows Platform Application.
 
-The Syncfusion Troubleshooter Visual Studio extension is installed along with the following Essential Studio setups. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter Visual Studio extension is installed along with the following Essential Studio<sup style="font-size:70%">&reg;</sup>  setups. 
 
-* Essential Studio for Windows Forms.
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Windows Forms.
 
-* Essential Studio for WPF.
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for WPF.
 
-* Essential Studio for ASP.NET Web Forms.
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET Web Forms.
 
-* Essential Studio for ASP.NET MVC.
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET MVC.
 
-* Essential Studio for ASP.NET Core.
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for ASP.NET Core.
 
-* Essential Studio for UWP.
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for UWP.
 
-* Essential Studio Enterprise Edition with any platform of mentioned above. 
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  Enterprise Edition with any platform of mentioned above. 

--- a/Extension/Syncfusion-Troubleshooter/Syncfusion-Troubleshooter.md
+++ b/Extension/Syncfusion-Troubleshooter/Syncfusion-Troubleshooter.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: Syncfusion Troubleshooter | Extension | Syncfusion
-description: Syncfusion Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in Syncfusion assembly reference, webconfig entries in projects.
+title: Syncfusion  Troubleshooter | Extension | Syncfusion
+description: Syncfusion  Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in Syncfusion  assembly reference, webconfig entries in projects.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Troubleshoot the project
 
-The Syncfusion Troubleshooter will be installed in Visual Studio along with Syncfusion Essential Studio setup installation. The Syncfusion Troubleshooter can be done the below items,
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be installed in Visual Studio along with Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  setup installation. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter can be done the below items,
 
 1. Report the Configuration issues.  
 
@@ -17,33 +17,33 @@ The Syncfusion Troubleshooter will be installed in Visual Studio along with Sync
 
 ## Report the Configuration issues
 
-The following steps help you to utilize the Syncfusion Troubleshooter by Visual Studio. 
+The following steps help you to utilize the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter by Visual Studio. 
 
-1. To open Syncfusion Troubleshooter Wizard, follow either one of the options below: 
+1. To open Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter Wizard, follow either one of the options below: 
    
    **Option 1:**  
-   Open an existing Syncfusion Application, choose **Syncfusion menu**. Then select corresponding platform menu and click **Troubleshoot…**
+   Open an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  Application, choose **Syncfusion menu**. Then select corresponding platform menu and click **Troubleshoot…**
 
-   ![Syncfusion Troubleshooter via Syncfusion menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter.png)
+   ![Syncfusion Troubleshooter via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter.png)
 
-   N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
    **Option 2:**  
    Right-click the Project file in Solution Explorer, then select the command **Syncfusion Troubleshooter…** Refer to the following screenshot for more information. 
 
    ![Syncfusion Troubleshooter add-in](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img1.jpeg)
 
-2. Now it’s analyze the project and it will report the project configuration issues of Syncfusion controls in the Troubleshooter dialog if any issues found. If the project doesn’t have any configuration issue, the dialog box will show there is no configuration changes required in following areas,
+2. Now it’s analyze the project and it will report the project configuration issues of Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in the Troubleshooter dialog if any issues found. If the project doesn’t have any configuration issue, the dialog box will show there is no configuration changes required in following areas,
 
-     * Syncfusion assembly references.
+     * Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly references.
 
-     * Syncfusion Web.config entries.
+     * Syncfusion<sup style="font-size:70%">&reg;</sup>  Web.config entries.
 
-     * Syncfusion NuGet Packages. 
+     * Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages. 
 
    ![No configuration changes required dialog box](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img2.jpeg)
 
-I> The Syncfusion Troubleshooter command will be visible only for Syncfusion projects that means the project should contain Syncfusion assemblies or Syncfusion NuGet packages referred.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter command will be visible only for Syncfusion<sup style="font-size:70%">&reg;</sup>  projects that means the project should contain Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages referred.
 
 Syncfusion Troubleshooter handles the below project configuration issues, 
 
@@ -55,25 +55,25 @@ Syncfusion Troubleshooter handles the below project configuration issues,
 
 ### Assembly Reference Issues
 
-The Syncfusion Troubleshooter deals with below assembly reference issues in Syncfusion Projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter deals with below assembly reference issues in Syncfusion<sup style="font-size:70%">&reg;</sup>  Projects. 
 
 1. Dependent assemblies are missing for referred assemblies from project. 
 
-   **For Instance:**  If “Syncfusion.Tools.WPF” assembly referred in project and “Syncfusion.Shared.WPF” (dependent of Syncfusion.Tools.WPF) not referred in project, Syncfusion Troubleshooter will be shown dependent assembly missing.
+   **For Instance:**  If “Syncfusion.Tools.WPF” assembly referred in project and “Syncfusion.Shared.WPF” (dependent of Syncfusion.Tools.WPF) not referred in project, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown dependent assembly missing.
 
    ![Dependent assemblies missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img3.jpg)
 
-2. Syncfusion assembly version mismatched. Compare to all Syncfusion assembly’s versions are in same project. If found any Syncfusion assembly version inconsistency, Syncfusion Troubleshooter will be shown Syncfusion assemblies version mismatched. 
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version mismatched. Compare to all Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly’s versions are in same project. If found any Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version inconsistency, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies version mismatched. 
 
-   **For Instance:**  If “Syncfusion.Tools.WPF” assembly (v15.2450.0.43) referred in project, but other Syncfusion assemblies referred assembly version is v15.2450.0.40.  Syncfusion Troubleshooter will be shown Syncfusion assembly version mismatched.
+   **For Instance:**  If “Syncfusion.Tools.WPF” assembly (v15.2450.0.43) referred in project, but other Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies referred assembly version is v15.2450.0.40.  Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version mismatched.
 
    ![Assembly version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img4.jpg)
 
-3. Framework version mismatching (Syncfusion Assemblies) with project’s .NET Framework version. Find the supported .NET Framework details for Syncfusion assemblies in below link,
+3. Framework version mismatching (Syncfusion Assemblies) with project’s .NET Framework version. Find the supported .NET Framework details for Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in below link,
 
    <https://help.syncfusion.com/common/essential-studio/assembly-information#supported-framework-version-for-essential-studio-assemblies> 
 
-   **For Instance:** The.NET Framework of the application is v4.5 and “Syncfusion.Tools.WPF” assembly (v15.2400.0.43 & .NET Framework version 4.0) referred in same application. The Syncfusion Troubleshooter will be shown Syncfusion assembly .NET Framework version is incompatible with project’s .NET Framework version.
+   **For Instance:** The.NET Framework of the application is v4.5 and “Syncfusion.Tools.WPF” assembly (v15.2400.0.43 & .NET Framework version 4.0) referred in same application. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly .NET Framework version is incompatible with project’s .NET Framework version.
 
    ![Target Framework version of application](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img5.jpg)
 
@@ -81,61 +81,61 @@ The Syncfusion Troubleshooter deals with below assembly reference issues in Sync
 
 ### Web.config Issues (for Web applications)
 
-The Syncfusion Troubleshooter deals with below web.config issues in Syncfusion web projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter deals with below web.config issues in Syncfusion<sup style="font-size:70%">&reg;</sup>  web projects. 
 
-1. Syncfusion assembly entry version mismatched. Each Syncfusion assembly entry version/.NET Framework version will be compared with corresponding referred Syncfusion assembly in the application.
+1. Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly entry version mismatched. Each Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly entry version/.NET Framework version will be compared with corresponding referred Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly in the application.
 
-   **For Instance:** If “Syncfusion.EJ.Export” assembly (v15.2450.0.46) referred in project, But “Syncfusion.EJ.Export” assembly entry version (v15.2450.0.33) in Web.config file. Syncfusion Troubleshooter will be shown Syncfusion assembly entry version mismatched.
+   **For Instance:** If “Syncfusion.EJ.Export” assembly (v15.2450.0.46) referred in project, But “Syncfusion.EJ.Export” assembly entry version (v15.2450.0.33) in Web.config file. Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly entry version mismatched.
 
    ![Syncfusion reference assembly entry version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img7.jpg)
 
-2. Multiple version and Duplicate Syncfusion assembly entry. Syncfusion Troubleshooter will show the duplicate assembly entry when Syncfusion assembly entry presented in Web.config which is not referred in project or multiple Syncfusion assembly entry in Web.config for same Syncfusion assembly. 
+2. Multiple version and Duplicate Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly entry. Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show the duplicate assembly entry when Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly entry presented in Web.config which is not referred in project or multiple Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly entry in Web.config for same Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly. 
 
-   **For Instance:** If project have “Syncfusion.EJ.Pivot” assembly (v15.2450.0.43) entry in Web.config file, But “Syncfusion.EJ.Pivot” assembly not referred in project. Syncfusion Troubleshooter will be show Duplicate assembly entry.
+   **For Instance:** If project have “Syncfusion.EJ.Pivot” assembly (v15.2450.0.43) entry in Web.config file, But “Syncfusion.EJ.Pivot” assembly not referred in project. Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be show Duplicate assembly entry.
  
-   ![Duplicate Syncfusion reference assembly entry issue shown in Troubleshooter wizard ](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img8.jpg)
+   ![Duplicate Syncfusion<sup style="font-size:70%">&reg;</sup>  reference assembly entry issue shown in Troubleshooter wizard ](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img8.jpg)
 
-   **For Instance:** If project Multiple “Syncfusion.EJ” assembly (v15.2400.0.46 && v15.2460.0.46) entry with mismatched assembly version/.NET Framework version in Web.config, Syncfusion Troubleshooter will show the Duplicate assembly entry and Multiple Syncfusion assembly entries.
+   **For Instance:** If project Multiple “Syncfusion.EJ” assembly (v15.2400.0.46 && v15.2460.0.46) entry with mismatched assembly version/.NET Framework version in Web.config, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show the Duplicate assembly entry and Multiple Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly entries.
 
-   ![Multiple version Syncfusion reference assembly entry issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img9.jpg)
+   ![Multiple version Syncfusion<sup style="font-size:70%">&reg;</sup>  reference assembly entry issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img9.jpg)
 
-3. Namespace entry missing. If any Syncfusion namespaces are missing in Web.config that is related to referred Syncfusion assemblies in project, Syncfusion Troubleshooter will show namespace entry is missing.
+3. Namespace entry missing. If any Syncfusion<sup style="font-size:70%">&reg;</sup>  namespaces are missing in Web.config that is related to referred Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in project, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show namespace entry is missing.
 
-   **For Instance:** If “Syncfusion.EJ.MVC” assembly (v15.2450.0.46) referred in project and “Syncfusion.MVC.EJ” namespace entry missing in Web.config file, Syncfusion Troubleshooter will show Syncfusion namespace entry missing.
+   **For Instance:** If “Syncfusion.EJ.MVC” assembly (v15.2450.0.46) referred in project and “Syncfusion.MVC.EJ” namespace entry missing in Web.config file, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  namespace entry missing.
    
    ![Namespace entry missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img10.jpg)
 
-4. Namespace entry version mismatched. If any Namespace entry version (assembly version) mismatched with corresponding referred assembly version in ASP.NET Web Application, Syncfusion Troubleshooter will be shown Namespace entry version mismatched.
+4. Namespace entry version mismatched. If any Namespace entry version (assembly version) mismatched with corresponding referred assembly version in ASP.NET Web Application, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Namespace entry version mismatched.
 
-   **For Instance:** If “Syncfusion.EJ” assembly (v15.2450.0.46) referred in project and “Syncfusion.JavaScript.DataVisualization” Namespace entry version (v15.2450.0.43) in Web.config file. Syncfusion Troubleshooter will be show Syncfusion namespace entry version mismatched.
+   **For Instance:** If “Syncfusion.EJ” assembly (v15.2450.0.46) referred in project and “Syncfusion.JavaScript.DataVisualization” Namespace entry version (v15.2450.0.43) in Web.config file. Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be show Syncfusion<sup style="font-size:70%">&reg;</sup>  namespace entry version mismatched.
 
    ![Syncfusion namespace entry version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img11.jpg)
 
-5. HTTP/Server handler entry mismatched. HTTP/Server handler entry version compare to corresponding referred assembly version in project. If any Syncfusion HTTP/Server handler entry version mismatched, Syncfusion Troubleshooter will show HTTP/Server handler entry mismatched.  
+5. HTTP/Server handler entry mismatched. HTTP/Server handler entry version compare to corresponding referred assembly version in project. If any Syncfusion<sup style="font-size:70%">&reg;</sup>  HTTP/Server handler entry version mismatched, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show HTTP/Server handler entry mismatched.  
 
-   **For Instance:** If “Syncfusion.EJ.” assembly (v15.2450.0.46) referred in project, But “Syncfusion.JavaScript.ImageHandler” HTTP/Server handler entry version (v15.2450.0.43) in Web.config file. Syncfusion Troubleshooter will be show Syncfusion HTTP/Server handler entry version mismatched.
+   **For Instance:** If “Syncfusion.EJ.” assembly (v15.2450.0.46) referred in project, But “Syncfusion.JavaScript.ImageHandler” HTTP/Server handler entry version (v15.2450.0.43) in Web.config file. Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be show Syncfusion<sup style="font-size:70%">&reg;</sup>  HTTP/Server handler entry version mismatched.
    
    ![Syncfusion HTTP/Server handler entry mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img12.jpg)
 
 ### NuGet Issues
 
-The Syncfusion Troubleshooter deals with below NuGet package related issues in Syncfusion projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter deals with below NuGet package related issues in Syncfusion<sup style="font-size:70%">&reg;</sup>  projects. 
 
-1. Multiple versions of Syncfusion NuGet Packages are installed. If Syncfusion NuGet Package version is differ from other Syncfusion NuGet Package version, Syncfusion Troubleshooter will be shown Syncfusion NuGet package version is mismatched. 
+1. Multiple versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages are installed. If Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package version is differ from other Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package version, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package version is mismatched. 
 
-   **For Instance:** Syncfusion.Web,Base package installed multiple version(v15.2.0.43 & v15.2.0.46), Syncfusion Troubleshooter will be shown Syncfusion package version mismatched.
+   **For Instance:** Syncfusion.Web,Base package installed multiple version(v15.2.0.43 & v15.2.0.46), Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  package version mismatched.
  
    ![Syncfusion NuGet Packages version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img13.jpg)
 
-2. Installed Syncfusion NuGet package’s Framework version is differing from the project’s .NET Framework version.
+2. Installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package’s Framework version is differing from the project’s .NET Framework version.
 
-   **For Instance:** Syncfusion.Calculate.Base NuGet package version(v15.2.0.46 with 4.0 Framework) installed in project, But the project .NET Framework version is 4.5. So, Syncfusion Troubleshooter will be show Syncfusion package Framework version is mismatched.
+   **For Instance:** Syncfusion.Calculate.Base NuGet package version(v15.2.0.46 with 4.0 Framework) installed in project, But the project .NET Framework version is 4.5. So, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be show Syncfusion<sup style="font-size:70%">&reg;</sup>  package Framework version is mismatched.
   
    ![Syncfusion NuGet packages Framework version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img14.jpg)
 
-3. Dependent NuGet package of the installed Syncfusion NuGet packages is missing.
+3. Dependent NuGet package of the installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages is missing.
 
-   **For Instance:** If install Syncfusion.Calculate.WPF NuGet package alone in project, Syncfusion Troubleshooter will show the Syncfusion.Calculate.Base dependent NuGet package missing.
+   **For Instance:** If install Syncfusion.Calculate.WPF NuGet package alone in project, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show the Syncfusion.Calculate.Base dependent NuGet package missing.
  
    ![Dependent NuGet package missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img15.jpg)
 
@@ -143,7 +143,7 @@ I> Internet connection is required to restore the missing dependent packages. If
 
 ## Apply the solution
 
-1. Once the Syncfusion Troubleshooter dialog loads, check the corresponding check box of the issue which you need to resolve. Then click the "Fix Issue(s)" button. 
+1. Once the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter dialog loads, check the corresponding check box of the issue which you need to resolve. Then click the "Fix Issue(s)" button. 
 
    ![Syncfusion Troubleshooter wizard with project configuration issues](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img16.jpeg)
 
@@ -151,10 +151,10 @@ I> Internet connection is required to restore the missing dependent packages. If
 
    ![Syncfusion Troubleshooter backup dialog](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img17.jpeg)
 
-3. Wait for a while, the Syncfusion Troubleshooter is being resolve the selected issues. Once the troubleshooting process completed, there will be a status message in the Visual Studio status bar as “Troubleshooting process completed successfully.” 
+3. Wait for a while, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter is being resolve the selected issues. Once the troubleshooting process completed, there will be a status message in the Visual Studio status bar as “Troubleshooting process completed successfully.” 
 
    ![Syncfusion Troubleshooter process success status message in visual studio status bar](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img18.jpeg)
 
-4. Then, Syncfusion licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/whats-new-in-2018-volume-2-licensing-changes-in-the-1620x-version-of-essential-studio.aspx) post for understanding the licensing changes introduced in Essential Studio.   
+4. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/whats-new-in-2018-volume-2-licensing-changes-in-the-1620x-version-of-essential-studio.aspx) post for understanding the licensing changes introduced in Essential Studio.   
 
-   ![Syncfusion license registration required information dialog in Syncfusion Troubleshooter](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img19.jpeg)
+   ![Syncfusion license registration required information dialog in Syncfusion  Troubleshooter](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img19.jpeg)

--- a/Extension/Syncfusion-Updates/Essential-Studio.md
+++ b/Extension/Syncfusion-Updates/Essential-Studio.md
@@ -1,31 +1,31 @@
 ---
 layout: post
-title: Check for updates | Extension | Syncfusion
-description: The Syncfusion check for updates automatically retrieves the latest Essential Studio and provide the download option.
+title: Check for updates | Extension | Syncfusion 
+description: The Syncfusion  check for updates automatically retrieves the latest Essential Studio  and provide the download option.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Update Essential Studio to the most recent release
+# Update Essential Studio<sup style="font-size:70%">&reg;</sup>  to the most recent release
 
-Syncfusion provides the Extensions to update most recent version of the Essential Studio release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
+Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the Extensions to update most recent version of the Essential Studio<sup style="font-size:70%">&reg;</sup>  release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
 
-I> The Syncfusion Check for updates extension is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Check for updates extension is available from v17.1.0.32.
 
 You can check updates availability in Visual Studio, and then install the update version if required.
 
-1. Choose **Syncfusion** **->** **Check** **for** **Updates…** in the Visual Studio menu.
+1. Choose **Syncfusion<sup style="font-size:70%">&reg;</sup> ** **->** **Check** **for** **Updates…** in the Visual Studio menu.
 
    ![Check for updates menu](CheckForUpdates_Images/CheckForUpdatesMenu.png)
 
-   N> *In Visual Studio 2019, Choose **Extensions** **->** **Syncfusion** **->** **Check** **for** **Updates…** in the Visual Studio menu.*
+   N> *In Visual Studio 2019, Choose **Extensions** **->** **Syncfusion<sup style="font-size:70%">&reg;</sup> ** **->** **Check** **for** **Updates…** in the Visual Studio menu.*
 
 2. When there is an update, **Update** dialog box opens.
 
    ![Update Available](CheckForUpdates_Images/UpdateAvailable1.png)
 
-3. You can download the Syncfusion Essential Studio from the Syncfusion website by selecting **Download**.
+3. You can download the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  from the Syncfusion<sup style="font-size:70%">&reg;</sup>  website by selecting **Download**.
 
-   N> *If you are using the latest version of Syncfusion Essential Studio, you will get the **No** **Updates** **are** **available** information.*  
+   N> *If you are using the latest version of Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio, you will get the **No** **Updates** **are** **available** information.*  
 

--- a/Extension/UWP-Extension/Overview.md
+++ b/Extension/UWP-Extension/Overview.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: UWP Extension | Extension | Syncfusion
-description: The Syncfusion UWP Project Templates provides quick access to create Syncfusion UWP Application by adding the required assemblies
+description: The Syncfusion  UWP Project Templates provides quick access to create Syncfusion  UWP Application by adding the required assemblies
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -11,29 +11,29 @@ documentation: ug
 
 ## Overview
  
-The Syncfusion UWP Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.The Syncfusion UWP Extensions supports Microsoft Visual Studio 2017.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Visual Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.The Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Extensions supports Microsoft Visual Studio 2017.
 
-I> The Syncfusion UWP menu option is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP menu option is available from v17.1.0.32.
 
-The Syncfusion provides the following extension supports in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the following extension supports in Visual Studio:
 
-1.	[Syncfusion UWP Project Template](https://help.syncfusion.com/extension/uwp-extension/project-templates): To create the Syncfusion UWP application by adding required Syncfusion assemblies/NuGet based on the control chosen.
-2.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the Syncfusion configuration and apply the fix like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly.
+1.	[Syncfusion UWP Project Template](https://help.syncfusion.com/extension/uwp-extension/project-templates): To create the Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP application by adding required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies/NuGet based on the control chosen.
+2.	[Troubleshooter](https://help.syncfusion.com/extension/syncfusion-troubleshooter/syncfusion-troubleshooter): Troubleshoot the project with the Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration and apply the fix like, wrong Framework Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly added to the project or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly.
 
 **No project selected in Visual Studio**
 
 ![Syncfusion Menu when No project selected in Visual Studio](Overview-images/Syncfusion_Menu_OverView1.png)
 
-**Selected Syncfusion UWP application in Visual Studio**
+**Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP application in Visual Studio**
 
-![Syncfusion Menu when Selected Syncfusion UWP application in Visual Studio](Overview-images/Syncfusion_Menu_OverView2.png)
+![Syncfusion Menu when Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP application in Visual Studio](Overview-images/Syncfusion_Menu_OverView2.png)
 
-N> In Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
-The Syncfusion UWP Visual Studio Extensions are installed along with the following setups,
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Visual Studio Extensions are installed along with the following setups,
 
-* Essential Studio for Enterprise Edition with the platform UWP
-* Essential Studio for UWP
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platform UWP
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for UWP
 
-N> The Syncfusion UWP Project Templates provide Visual Studio 2015 support from v15.3.0.26 to v16.4.0.52.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Project Templates provide Visual Studio 2015 support from v15.3.0.26 to v16.4.0.52.
 

--- a/Extension/UWP-Extension/Project-Templates.md
+++ b/Extension/UWP-Extension/Project-Templates.md
@@ -1,41 +1,41 @@
 ---
 layout: post
-title: Syncfusion UWP Project Templates | Extension | Syncfusion
-description: Syncfusion provides the Visual Studio Project Templates for the Syncfusion UWP platform to create Syncfusion UWP Applications
+title: Syncfusion  UWP Project Templates | Extension | Syncfusion
+description: Syncfusion  provides the Visual Studio Project Templates for the Syncfusion  UWP platform to create Syncfusion  UWP Applications
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Project Templates
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Project Templates
 
-Syncfusion provides the **Visual** **Studio** **Project** **Templates** for the Syncfusion UWP platform to create Syncfusion UWP Applications.  
+Syncfusion provides the **Visual** **Studio** **Project** **Templates** for the Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP platform to create Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Applications.  
 
-I> The Syncfusion UWP project templates are available from v15.3.0.26.  
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP project templates are available from v15.3.0.26.  
 
-## Create Syncfusion UWP Application
+## Create Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Application
 
 The following steps help you to create the **Syncfusion** **UWP** **Application** through the **Visual** **Studio** **Project** **Template**.
 
-> Before use the Syncfusion UWP Project Template, check whether the **UWP Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Project Template, check whether the **UWP Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.
 
-1. To create a Syncfusion UWP project, follow either one of the options below:
+1. To create a Syncfusion  UWP project, follow either one of the options below:
 
    **Option 1:**   
-   Click **Syncfusion Menu** and choose **Essential Studio for UWP > Create New Syncfusion Project…** in **Visual Studio**.
+   Click **Syncfusion Menu** and choose **Essential Studio for UWP > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** in **Visual Studio**.
    
-   ![Choose Syncfusion Universal Windows Application from Visual Studio new project dialog via Syncfusion menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate.png)
+   ![Choose Syncfusion<sup style="font-size:70%">&reg;</sup>  Universal Windows Application from Visual Studio new project dialog via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate.png)
 
-   N> In Visual Studio 2019, Syncfusion menu under Extension in Visual Studio menu.
+   N> In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu under Extension in Visual Studio menu.
 
    **Option 2:**  
-   Choose **File > New > Project** and navigate to **Syncfusion > Windows Universal> Syncfusion Universal Windows Application** in **Visual Studio**.
+   Choose **File > New > Project** and navigate to **Syncfusion > Windows Universal> Syncfusion<sup style="font-size:70%">&reg;</sup>  Universal Windows Application** in **Visual Studio**.
 
-   ![Choose Syncfusion Universal Windows Application from Visual Studio new project dialog](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img1.jpeg)
+   ![Choose Syncfusion  Universal Windows Application from Visual Studio new project dialog](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img1.jpeg)
 
 2. Name the **Project** and choose the destination location if required, then click **OK**. 
 
-3. Then Project Configuration Wizard appears. Choose the options to configure the Syncfusion Universal Windows Platform application by using the following Project Configuration dialog.
+3. Then Project Configuration Wizard appears. Choose the options to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  Universal Windows Platform application by using the following Project Configuration dialog.
 
    ### Project configurations:
 
@@ -49,22 +49,22 @@ The following steps help you to create the **Syncfusion** **UWP** **Application*
 
    **Template Type:** Select the template type of UWP Project, either Blank or Hamburger Menu or Hamburger Menu (MVVM).
 
-   **Components:** Choose the required Syncfusion components to configure.
+   **Components:** Choose the required Syncfusion<sup style="font-size:70%">&reg;</sup>  components to configure.
    
    ![Syncfusion UWP Project configuration wizard](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img4.jpeg)
    
-   N> If SDK is chosen as the reference type, then all the Syncfusion UWP controls will be added. So, you no need to select any components.
+   N> If SDK is chosen as the reference type, then all the Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP controls will be added. So, you no need to select any components.
    
-4. Once you click Create button, the Syncfusion UWP Application is created.
+4. Once you click Create button, the Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Application is created.
 
-5. Once the Project Configuration Wizard is done, the Syncfusion UWP Application is created with required SDK/references and pages.
+5. Once the Project Configuration Wizard is done, the Syncfusion<sup style="font-size:70%">&reg;</sup>  UWP Application is created with required SDK/references and pages.
 
    ![Syncfusion UWP Project created with SDK reference](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img5.jpeg)
 
    ![Syncfusion UWP Project created with readme](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img7.PNG)
 
-6. Then, Syncfusion licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown as follow, if you are installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Please navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key) which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
-   ![Syncfusion license registration required information dialog in Syncfusion UWP Project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img6.jpeg)   
+   ![Syncfusion license registration required information dialog in Syncfusion  UWP Project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img6.jpeg)   
 
 

--- a/Extension/UWP-Extension/Syncfusion-Notifications.md
+++ b/Extension/UWP-Extension/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications | Extension | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in UWP applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in UWP applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> UWP**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> UWP**
 
 ![Option Page](images/uwp-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your UWP application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your UWP application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/uwp-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/uwp-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio Universal Windows,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your UWP development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio<sup style="font-size:70%">&reg;</sup> Universal Windows,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your UWP development projects.
 
 ![Build Notification](images/uwp-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your UWP application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your UWP application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/uwp-invalid.png)
 

--- a/Extension/WPF-Extension/Add-Item.md
+++ b/Extension/WPF-Extension/Add-Item.md
@@ -1,58 +1,58 @@
 ---
 layout: post
 title: Syncfusion Item Template for WPF | Wpf | Syncfusion
-description: Syncfusion item template extension supports to add the Syncfusion WPF Window into WPF application with add Syncfusion WPF references.
+description: Syncfusion  item template extension supports to add the Syncfusion  WPF Window into WPF application with add Syncfusion  WPF references.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 
-# Add Syncfusion Components to the WPF Application
+# Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Components to the WPF Application
 
-Syncfusion supports Visual Studio Item Templates to add Syncfusion WPF Components to a WPF application with Syncfusion WPF references. 
+Syncfusion supports Visual Studio Item Templates to add Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Components to a WPF application with Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF references. 
 
-I> The Syncfusion WPF item templates are available from v19.1.0.54. 
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF item templates are available from v19.1.0.54. 
 
-The following steps will guide you to add the Syncfusion WPF Components to your Visual Studio WPF application.
+The following steps will guide you to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Components to your Visual Studio WPF application.
 
 > Check whether the **WPF Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by going to **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 or later and Visual Studio 2017 or lower by going to **Tools -> Extensions and Updates -> Installed**. If this extension is not installed, please install the extension by following the steps from the [download and installation](https://help.syncfusion.com/wpf/visual-studio-integration/download-and-installation) help topic.
 
-## Add Components using Syncfusion Item Template
+## Add Components using Syncfusion<sup style="font-size:70%">&reg;</sup>  Item Template
 
 1.	Open a new or existing WPF application.
 
 	**Option 1:**
 
-2.	From the **Solution Explorer, right-click** on the WPF application. Choose **Add Syncfusion Item...**.
+2.	From the **Solution Explorer, right-click** on the WPF application. Choose **Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Item...**.
 
-	![Choose Add Syncfusion Item option from right click project](Add-Item-images/Add-syncfusion-item.png)
+	![Choose Add Syncfusion  Item option from right click project](Add-Item-images/Add-syncfusion-item.png)
 
 	**Option 2:**
 
-3.	Click **Extensions > Essential Studio for WPF > Add Syncfusion Item…** in Visual Studio.
+3.	Click **Extensions > Essential Studio<sup style="font-size:70%">&reg;</sup>  for WPF > Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Item…** in Visual Studio.
 
-	![Choose Add Syncfusion Item option from menu](Add-Item-images/Add-item.png)
+	![Choose Add Syncfusion  Item option from menu](Add-Item-images/Add-item.png)
 
 
-4.	The Syncfusion WPF Item Template wizard will be launched as follows.
+4.	The Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Item Template wizard will be launched as follows.
 
 	![Syncfusion WPF Item template Components](Add-Item-images/Add-syncfusion-ui.png)
 
 5.	Select the WPF Components from the Component list within your WPF Item Template. The features associated with the selected Component will be presented. From here, 		choose the specific features that are essential for your project.
 
-6.	Choose an assembly reference option such as GAC location, Essential Studio installed location, or NuGet packages to specify where the required Syncfusion assemblies 	are added to the project.
+6.	Choose an assembly reference option such as GAC location, Essential Studio<sup style="font-size:70%">&reg;</sup>  installed location, or NuGet packages to specify where the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies 	are added to the project.
 
-	N> If the Syncfusion Essential WPF build is installed, the Installed location and GAC options will be enabled. Without installing the Syncfusion Essential WPF setup, use the NuGet option. The GAC option will not be available when using the Syncfusion WPF Components in a .NET Core application. The Version drop-down lists the installed WPF versions.
+	N> If the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF build is installed, the Installed location and GAC options will be enabled. Without installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF setup, use the NuGet option. The GAC option will not be available when using the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Components in a .NET Core application. The Version drop-down lists the installed WPF versions.
 
 7.  Click **Add**, and a pop-up will appear providing information about adding Component **files** and **NuGet/Assemblies** details.
 
 	![Syncfusion WPF Item template details](Add-Item-images/Add-syncfusion-item-3.png)	
 
-8.	Click **OK** to incorporate the chosen Components into the WPF application, along with the necessary Syncfusion assemblies.
+8.	Click **OK** to incorporate the chosen Components into the WPF application, along with the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies.
 
 	![Syncfusion WPF Item template Gallery](Add-Item-images/Add-syncfusion-item-details.png)
 
-9.	Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the 			licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/			licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to 		your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post 	for understanding the licensing changes introduced in Essential Studio.
+9.	Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the 			licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/			licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to 		your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post 	for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
     ![Syncfusion WPF Item template Gallery](Add-Item-images/LicensePage.png)

--- a/Extension/WPF-Extension/Add-References.md
+++ b/Extension/WPF-Extension/Add-References.md
@@ -1,34 +1,34 @@
 ---
 layout: post
 title: Add References| Wpf | Syncfusion
-description: Syncfusion Reference Manger extension is add-in to add the Syncfusion references into the WinForms application
+description: Syncfusion  Reference Manger extension is add-in to add the Syncfusion  references into the WinForms application
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Add Reference for WPF
 
-Syncfusion Reference Manager is the Visual Studio Add-In for WPF platform. It adds the Syncfusion assembly reference to the project, either from the GAC location or from Essential Studio installed location or from NuGet packages. It can also migrate the projects that contain the old versions of the Syncfusion assembly reference to newer or specific versions of the Syncfusion assembly reference. It supports Microsoft Visual Studio 2013 or higher. This Visual Studio extension is included from Essential Studio 2013 Volume 3 release.
+Syncfusion<sup style="font-size:70%">&reg;</sup> Reference Manager is the Visual Studio Add-In for WPF platform. It adds the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference to the project, either from the GAC location or from Essential Studio<sup style="font-size:70%">&reg;</sup>  installed location or from NuGet packages. It can also migrate the projects that contain the old versions of the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference to newer or specific versions of the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference. It supports Microsoft Visual Studio 2013 or higher. This Visual Studio extension is included from Essential Studio<sup style="font-size:70%">&reg;</sup>  2013 Volume 3 release.
 
-N> This Reference Manager can be applied to a project for Syncfusion assembly versions 10.4.0.71 and later.
+N> This Reference Manager can be applied to a project for Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly versions 10.4.0.71 and later.
 
-To add the Syncfusion assembly references in Visual Studio, follow the steps below:
+To add the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly references in Visual Studio, follow the steps below:
 
-> Check whether the **WPF Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by going to **Tools -> Extensions and Updates -> Installed** for Visual Studio 2017 or lower, and **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 by going to Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
+> Check whether the **WPF Extensions - Syncfusion<sup style="font-size:70%">&reg;</sup>** are installed or not in Visual Studio Extension Manager by going to **Tools -> Extensions and Updates -> Installed** for Visual Studio 2017 or lower, and **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 by going to Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
 
 1. Open a new or existing **WPF** application.
 
-2. To open Syncfusion Reference Manager Wizard, follow either one of the options below:
+2. To open Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager Wizard, follow either one of the options below:
 
    **Option 1:**  
-   Click **Syncfusion Menu** and choose **Essential Studio for WPF > Add References…** in **Visual Studio**.
+   Click **Syncfusion<sup style="font-size:70%">&reg;</sup> Menu** and choose **Essential Studio<sup style="font-size:70%">&reg;</sup> for WPF > Add References…** in **Visual Studio**.
 
-   ![Syncfusion Reference Manager via Syncfusion Menu](Syncfusion-Reference-Manger_images/Syncfusion_Menu_AddReference.png)
+   ![Syncfusion Reference Manager via Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu](Syncfusion-Reference-Manger_images/Syncfusion_Menu_AddReference.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
-   ![Syncfusion Reference Manager via Syncfusion Menu](Syncfusion-Reference-Manger_images/Syncfusion_Menu_AddReference_2019.png)
+   ![Syncfusion Reference Manager via Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu](Syncfusion-Reference-Manger_images/Syncfusion_Menu_AddReference_2019.png)
 
    **Option 2:**  
 
@@ -36,54 +36,54 @@ To add the Syncfusion assembly references in Visual Studio, follow the steps bel
 
    ![Syncfusion Reference Manager add-in](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img1.png)
 
-3. The Syncfusion Reference Manager Wizard displays a list of loaded Syncfusion WPF controls.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager Wizard displays a list of loaded Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF controls.
 
    ![Syncfusion Reference Manger Wizard](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img2.png)
 
-   **Platform Selection:** Platform selection option will appear as an option in Syncfusion Reference Manager if opened from a Console/Class Library project. Select the appropriate platform. 
+   **Platform Selection:** Platform selection option will appear as an option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager if opened from a Console/Class Library project. Select the appropriate platform. 
 
-   ![Platform selection option in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img3.png)
+   ![Platform selection option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img3.png)
 
-   N> The platform selection option will appear only if Essential Studio for Enterprise Edition with the platforms WPF and Windows Forms has been installed, or if both Essential Studio for WPF and WinForms has been installed.
+   N> The platform selection option will appear only if Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platforms WPF and Windows Forms has been installed, or if both Essential Studio<sup style="font-size:70%">&reg;</sup>  for WPF and WinForms has been installed.
 
    **Assembly From:** Choose the assembly location, either from NuGet packages, the build installed location, or by using the GAC location.
 
-   N> The installed location and GAC option will be available only when the Syncfusion Essential Studio WPF setup has been installed.
+   N> The installed location and GAC option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  WPF setup has been installed.
 
-   ![Assembly location option in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img4.png)
+   ![Assembly location option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img4.png)
 
 
    N> The GAC option will not be available when you select the WPF (.NET 8.0, .NET 7.0, and.NET 6.0) application in Visual Studio 2022.
 
    **Version:** To add the corresponding version assemblies to the project, select the build version.
 
-   ![Assembly location option in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger1-img4.png)
+   ![Assembly location option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger1-img4.png)
 
 
    **Themes Option:** Choose the necessary themes based on your requirements. To learn more about built-in themes and their available assembly, click the link below.
 
    [https://help.syncfusion.com/wpf/themes/](https://help.syncfusion.com/wpf/themes/)
 
-   ![Themes selection option in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img5.png)
+   ![Themes selection option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img5.png)
 
    N> Themes option will be enabled only if we selected theme supported controls.
 
-   ![Themes selection option notification in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img6.png)
+   ![Themes selection option notification in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img6.png)
 
 
 4. Select the required controls you want to add in your project. Then click ****Done** to add the project's required assemblies for the specified controls. The list of required assemblies for the selected controls to be added is shown in the screenshot below.
 
    ![Syncfusion Reference Manager new assemblies add information dialog](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img7.png)
 
-5. Click **OK**. The listed Syncfusion assemblies are added to project. Then it notifies “Syncfusion assemblies have been added successfully” in Visual Studio status bar.
+5. Click **OK**. The listed Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies are added to project. Then it notifies “Syncfusion assemblies have been added successfully” in Visual Studio status bar.
 
    ![Syncfusion Reference Manager success status in Visual Studio status bar](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img8.png)
 
-6. Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-   ![Syncfusion license registration required information dialog in Syncfusion Reference Manager](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img9.png)
+   ![Syncfusion license registration required information dialog in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img9.png)
 
-N>  Reference Manager support is provided by Syncfusion for select versions of the.NET Framework that are included (as assemblies) in the Syncfusion Essential Studio installation. If you try to add Syncfusion assemblies to a project and the project framework isn't compatible with the specified Syncfusion version assemblies, a dialogue box shows with the message "**Current build v{version} isn't compatible with this framework v{Framework} Version**".
+N>  Reference Manager support is provided by Syncfusion<sup style="font-size:70%">&reg;</sup>  for select versions of the.NET Framework that are included (as assemblies) in the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  installation. If you try to add Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies to a project and the project framework isn't compatible with the specified Syncfusion<sup style="font-size:70%">&reg;</sup>  version assemblies, a dialogue box shows with the message "**Current build v{version} isn't compatible with this framework v{Framework} Version**".
 
 
 

--- a/Extension/WPF-Extension/Check-for-Updates.md
+++ b/Extension/WPF-Extension/Check-for-Updates.md
@@ -1,17 +1,17 @@
 ---
 layout: post
 title: Check for Updates | Wpf | Syncfusion
-description: Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio release.
+description: Syncfusion  Check for Updates provides Extensions to update most recent version of the Essential Studio release.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Check for Updates in Syncfusion Essential WPF
+# Check for Updates in Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF
 
-Syncfusion provides Extensions to update the most recent version of the Essential Studio release. Installing the most recent version ensures that you always have the most up-to-date features, fixes, and improvements.
+Syncfusion provides Extensions to update the most recent version of the Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Installing the most recent version ensures that you always have the most up-to-date features, fixes, and improvements.
 
-I> The Syncfusion Check for updates is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Check for updates is available from v17.1.0.32.
 
 You can check the availability of updates in Visual Studio and then install the update version if required.
 
@@ -19,7 +19,7 @@ You can check the availability of updates in Visual Studio and then install the 
 
 	![Syncfusion check for updates menu](Check-for-Updates_images/Check-for-Updates_images-img1.png)
 
-	N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+	N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
 	![Syncfusion check for updates menu](Check-for-Updates_images/Check-for-Updates_images-img1_2019.png)
    
@@ -27,4 +27,4 @@ You can check the availability of updates in Visual Studio and then install the 
 
 	![Syncfusion check for updates wizard](Check-for-Updates_images/Check-for-Updates_images-img2.png)
 
-3.	Syncfusion Essential Studio can be downloaded from the Syncfusion website by clicking the **Download** button.
+3.	Syncfusion Essential Studio<sup style="font-size:70%">&reg;</sup>  can be downloaded from the Syncfusion<sup style="font-size:70%">&reg;</sup>  website by clicking the **Download** button.

--- a/Extension/WPF-Extension/Create-Project.md
+++ b/Extension/WPF-Extension/Create-Project.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Create Project | Wpf | Syncfusion
-description: Syncfusion provides the Visual Studio Project Templates for the Syncfusion WPF platform to create Syncfusion WPF Application by addiing the required assemblies
+description: Syncfusion  provides the Visual Studio Project Templates for the Syncfusion  WPF platform to create Syncfusion  WPF Application by addiing the required assemblies
 platform: extension
 control: Syncfusion Extensions
 documentation: ug
@@ -10,43 +10,43 @@ documentation: ug
 
 # Create WPF application
 
-The Visual Studio Project Templates for the Syncfusion WPF platform allow you to quickly develop a Syncfusion WPF application by just adding the appropriate Syncfusion assemblies and XAML. 
+The Visual Studio Project Templates for the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF platform allow you to quickly develop a Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF application by just adding the appropriate Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and XAML. 
 
-I> The Syncfusion WPF templates are available from v16.1.0.24. 
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF templates are available from v16.1.0.24. 
 
 > WPF Project Template works seamlessly with Visual Studio 2015 or lower. For the Visual Studio 2017 or later versions, it is recommended to use a [WPF Template Studio](https://help.syncfusion.com/wpf/visual-studio-integration/template-studio).
 
-Create the Syncfusion WPF project using the Visual Studio Project Template by following the steps below: 
+Create the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF project using the Visual Studio Project Template by following the steps below: 
 
 > Check whether the **WPF Extensions - Syncfusion** are installed or not in Visual Studio 2015 or lower by going to **Tools -> Extensions and Updates -> Installed**. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://help.syncfusion.com/wpf/visual-studio-integration/download-and-installation) help topic.
 
-1.	To create a Syncfusion WPF project, follow either one of the options below:
+1.	To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF project, follow either one of the options below:
 
 	**Option 1:**  
-	Click **Syncfusion** Menu and choose **Essential Studio for WPF > Create New Syncfusion Project…**  in **Visual Studio**.
+	Click **Syncfusion** Menu and choose **Essential Studio for WPF > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…**  in **Visual Studio**.
     
-	![Choose Syncfusion WPF Application from Visual Studio new project dialog via Syncfusion menu](Project-Template-images/Syncfusion-Menu.png)
+	![Choose Syncfusion  WPF Application from Visual Studio new project dialog via Syncfusion menu](Project-Template-images/Syncfusion-Menu.png)
 
-	N> In Visual Studio 2015 or lower, you can see the  Syncfusion menu directly in the Visual Studio menu.
+	N> In Visual Studio 2015 or lower, you can see the  Syncfusion<sup style="font-size:70%">&reg;</sup>  menu directly in the Visual Studio menu.
 
 	**Option 2:**   
-	Choose **File -> New -> Project**. Opens a new dialog to create a new project. By filtering the project type with Syncfusion or using the Syncfusion keyword in the search option, you can get the templates offered by Syncfusion for WPF.
+	Choose **File -> New -> Project**. Opens a new dialog to create a new project. By filtering the project type with Syncfusion<sup style="font-size:70%">&reg;</sup>  or using the Syncfusion<sup style="font-size:70%">&reg;</sup>  keyword in the search option, you can get the templates offered by Syncfusion<sup style="font-size:70%">&reg;</sup>  for WPF.
 
-	![Choose Syncfusion WPF Application from Visual Studio new project dialog](Project-Template-images/Syncfusion-Project-Template-Gallery2019-1.png)
+	![Choose Syncfusion  WPF Application from Visual Studio new project dialog](Project-Template-images/Syncfusion-Project-Template-Gallery2019-1.png)
 
-	In Visual Studio 2015 or lower, Select **File > New > Project** and navigate to **Syncfusion > Windows > Syncfusion WPF Application** in Visual Studio. 
+	In Visual Studio 2015 or lower, Select **File > New > Project** and navigate to **Syncfusion > Windows > Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Application** in Visual Studio. 
 
-	![Choose Syncfusion WPF Application from Visual Studio new project dialog](Project-Template-images/Syncfusion-Project-Template-Gallery-1.png)
+	![Choose Syncfusion  WPF Application from Visual Studio new project dialog](Project-Template-images/Syncfusion-Project-Template-Gallery-1.png)
 
 2.	Name the **Project**, select the destination location when required, and specify the Framework of the project, then click **OK**.  
 
-	N> For Syncfusion WPF project templates, the minimum target Framework is 4.0. 
+	N> For Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF project templates, the minimum target Framework is 4.0. 
 
-3.	Using the following Project Configuration Wizard, choose the options to configure the Syncfusion WPF Application.  
+3.	Using the following Project Configuration Wizard, choose the options to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Application.  
   
 	![Syncfusion WPF project configuration wizard](Project-Template-images/Syncfusion-Project-Template-Gallery2019-2.png)
                                                  
-	In Visual Studio 2015 or lower, Syncfusion WPF Application project configuration wizard. 
+	In Visual Studio 2015 or lower, Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Application project configuration wizard. 
 
 	![Syncfusion WPF project configuration wizard](Project-Template-images/Syncfusion-Project-Template-Gallery-2.png)
 
@@ -58,13 +58,13 @@ Create the Syncfusion WPF project using the Visual Studio Project Template by fo
 
 	**Choose Theme:** Select the required theme.
 
-	**Reference From:** Choose the assembly location such as NuGet, GAC Location, or Essential Studio installed location, from where the assembly is added to the project.
+	**Reference From:** Choose the assembly location such as NuGet, GAC Location, or Essential Studio<sup style="font-size:70%">&reg;</sup>  installed location, from where the assembly is added to the project.
 
-	N> The installed location and GAC options will be available only after the Syncfusion Essential WPF setup has been installed. You can use the NuGet option instead of installing the Syncfusion Essential WPF setup.
+	N> The installed location and GAC options will be available only after the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF setup has been installed. You can use the NuGet option instead of installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF setup.
 
 	**Installed ES Build Version:** To add the appropriate version assemblies to the project, choose the build version.
 
-	N> Installed ES build version option will be available only if you install the Syncfusion Essential WPF setup and select Installed Location or GAC as the assembly location.
+	N> Installed ES build version option will be available only if you install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF setup and select Installed Location or GAC as the assembly location.
 
 	**Size Mode:** Select the Size Mode either Default or Touch.
 
@@ -72,14 +72,14 @@ Create the Syncfusion WPF project using the Visual Studio Project Template by fo
 
 	N> Project create option will be enabled only if you have selected the window
       
-4.	After choosing above project configuration options in the Project Configuration Wizard, click the create button then Syncfusion WPF project is created with the necessary XAML files and required Syncfusion WPF assemblies/NuGet packages. 
+4.	After choosing above project configuration options in the Project Configuration Wizard, click the create button then Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF project is created with the necessary XAML files and required Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF assemblies/NuGet packages. 
 
-	![Syncfusion WPF project created with required Syncfusion WPF assemblies](Project-Template-images/Syncfusion-Project-Template-Gallery-7.png)
+	![Syncfusion WPF project created with required Syncfusion  WPF assemblies](Project-Template-images/Syncfusion-Project-Template-Gallery-7.png)
 
-	![Syncfusion WPF project created with required Syncfusion XAML files](Project-Template-images/Syncfusion-Project-Template-Gallery-8.png)
+	![Syncfusion WPF project created with required Syncfusion  XAML files](Project-Template-images/Syncfusion-Project-Template-Gallery-8.png)
 
 	![Syncfusion WPF project created with readme](Project-Template-images/Syncfusion-Project-Template-Gallery-10.png)
 
-5.	Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio.
+5.	Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-	![Syncfusion license registration required information dialog in Syncfusion WPF project](Project-Template-images/Syncfusion-Project-Template-Gallery-9.png)   
+	![Syncfusion license registration required information dialog in Syncfusion  WPF project](Project-Template-images/Syncfusion-Project-Template-Gallery-9.png)   

--- a/Extension/WPF-Extension/Download-and-Installation.md
+++ b/Extension/WPF-Extension/Download-and-Installation.md
@@ -1,20 +1,20 @@
 ---
 layout: post
 title: Download and Installation | Wpf | Syncfusion
-description: How to download and install the Syncfusion WPF Visual Studio Extensions from Visual Studio Market Place
+description: How to download and install the Syncfusion  WPF Visual Studio Extensions from Visual Studio Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 
 # Download and Installation
 
-In [Visual Studio marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.WPFExtension), Syncfusion publishing the WPF Visual Studio extension. You can either use the Visual Studio to install it or go to the Visual Studio marketplace to download and install it
+In [Visual Studio marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.WPFExtension), Syncfusion<sup style="font-size:70%">&reg;</sup>  publishing the WPF Visual Studio extension. You can either use the Visual Studio to install it or go to the Visual Studio marketplace to download and install it
 
 ## Install through the Visual Studio Manage Extensions
 
-The steps below assist you to how to install the Syncfusion WPF extensions from Visual Studio **Manage Extensions**.
+The steps below assist you to how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF extensions from Visual Studio **Manage Extensions**.
 
 1.	Open the Visual Studio.
 2.	Navigate to **Extension -> Manage Extensions** and open the Manage Extensions.
@@ -28,13 +28,13 @@ The steps below assist you to how to install the Syncfusion WPF extensions from 
 	![Vsix Modify Window](Download-and-Installation-images/VSIXModify.PNG)
 6.	Click the **Modify** button.
 7.	When the installation is finished, launch the Visual Studio.
-8.	Now, you can use the Syncfusion extensions from Visual Studio under the Extensions menu.
+8.	Now, you can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from Visual Studio under the Extensions menu.
 	
 	![Syncfusion WPF Menu](Download-and-Installation-images/SyncfusionWpfMenu.png)
 
 ##	Install from the Visual Studio Marketplace
 
-The steps below illustrate how to download and install the Syncfusion WPF extension from the Visual Studio Marketplace.
+The steps below illustrate how to download and install the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF extension from the Visual Studio Marketplace.
 
 1.	Download the [Syncfusion WPF Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.WPFExtension) from the Visual Studio Marketplace.
 2.	If any Visual Studio instances are still open, close them.
@@ -42,6 +42,6 @@ The steps below illustrate how to download and install the Syncfusion WPF extens
 	
 	![Vsix Modify Window](Download-and-Installation-images/VSIXInstall.png)
 4.	Click the **Install** button.
-5.	After the installation is complete, open Visual Studio 2019. You can now use Syncfusion extensions from the Visual Studio under the Extensions menu.
+5.	After the installation is complete, open Visual Studio 2019. You can now use Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio under the Extensions menu.
 	
 	![Syncfusion WPF Menu](Download-and-Installation-images/SyncfusionWpfMenu.png)

--- a/Extension/WPF-Extension/Overview.md
+++ b/Extension/WPF-Extension/Overview.md
@@ -1,32 +1,32 @@
 ---
 layout: post
 title: Visual Studio Extension for WPF | Syncfusion
-description: The Syncfusion WPF Visual Studio Extensions provides you with quick access to Project Templates to create or configure the WPF Application.
+description: The Syncfusion  WPF Visual Studio Extensions provides you with quick access to Project Templates to create or configure the WPF Application.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion WPF Extension
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Extension
 
-The Syncfusion WPF Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.The Syncfusion WPF Extensions supports Microsoft Visual Studio 2013 or higher.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.The Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Extensions supports Microsoft Visual Studio 2013 or higher.
 
-N> Syncfusion Extension is published in Visual Studio Marketplace. We provided separate Syncfusion WPF Extension support for Visual Studio 2022 and Visual Studio 2019 or lower. Please refer below marketplace link.
+N> Syncfusion<sup style="font-size:70%">&reg;</sup>  Extension is published in Visual Studio Marketplace. We provided separate Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Extension support for Visual Studio 2022 and Visual Studio 2019 or lower. Please refer below marketplace link.
 
 [Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.WPFVSExtension)
 
 [Visual Studio 2019 or lower](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.WPFExtension)
 
-I> The Syncfusion WPF menu option is available from `v17.1.0.32`.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF menu option is available from `v17.1.0.32`.
 
-The Syncfusion provides the following extension supports in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the following extension supports in Visual Studio:
 
-1.  [Template Studio](https://help.syncfusion.com/wpf/visual-studio-integration/template-studio): Syncfusion WPF Template Studio simplifies application development with its components by managing references and providing pre-defined code. It streamlines the process of creating WPF applications.
-2.	[Create Project](https://help.syncfusion.com/wpf/visual-studio-integration/create-project): Creates the Syncfusion WPF application by adding the required Syncfusion assemblies and XMAL.
-3.	[Add Item](https://help.syncfusion.com/wpf/visual-studio-integration/add-item): Add Syncfusion WPF Controls into the WPF application with add Syncfusion WPF assemblies/NuGet packages
-4.	[Add References](https://help.syncfusion.com/wpf/visual-studio-integration/add-references): Add the required Syncfusion assembly to WPF project reference based on the selected control(s).
-5.	[Toolbox Configuration](https://help.syncfusion.com/wpf/visual-studio-integration/toolbox-configuration): Configure the Syncfusion controls into the Visual Studio .NET toolbox.
-6.	[Troubleshooter](https://help.syncfusion.com/wpf/visual-studio-integration/troubleshooting): Troubleshoots the project with the Syncfusion configuration and apply the fix like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly.
+1.  [Template Studio](https://help.syncfusion.com/wpf/visual-studio-integration/template-studio): Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Template Studio simplifies application development with its components by managing references and providing pre-defined code. It streamlines the process of creating WPF applications.
+2.	[Create Project](https://help.syncfusion.com/wpf/visual-studio-integration/create-project): Creates the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and XMAL.
+3.	[Add Item](https://help.syncfusion.com/wpf/visual-studio-integration/add-item): Add Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Controls into the WPF application with add Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF assemblies/NuGet packages
+4.	[Add References](https://help.syncfusion.com/wpf/visual-studio-integration/add-references): Add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly to WPF project reference based on the selected control(s).
+5.	[Toolbox Configuration](https://help.syncfusion.com/wpf/visual-studio-integration/toolbox-configuration): Configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  controls into the Visual Studio .NET toolbox.
+6.	[Troubleshooter](https://help.syncfusion.com/wpf/visual-studio-integration/troubleshooting): Troubleshoots the project with the Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration and apply the fix like, wrong Framework Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly added to the project or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly.
 
 **No project selected in Visual Studio**
 
@@ -36,8 +36,8 @@ The Syncfusion provides the following extension supports in Visual Studio:
 
 ![Syncfusion Menu when Selected Microsoft WPF application in Visual Studio](Overview-images/WPF-1.png)
 
-**Selected Syncfusion WPF application in Visual Studio**
+**Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF application in Visual Studio**
 
 ![Syncfusion Menu when Selected Synfusion WPF application in Visual Studio](Overview-images/WPF-1.png)
 
-N> In Visual Studio 2017 or lower, you can see the Syncfusion menu directly in the Visual Studio menu.
+N> In Visual Studio 2017 or lower, you can see the Syncfusion<sup style="font-size:70%">&reg;</sup>  menu directly in the Visual Studio menu.

--- a/Extension/WPF-Extension/Syncfusion-Notifications.md
+++ b/Extension/WPF-Extension/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications | WPF | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in WPF applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in WPF applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> WPF**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> WPF**
 
 ![Option Page](images/wpf-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your WPF application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your WPF application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/wpf-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/wpf-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio WPF,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your WPF development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio WPF,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your WPF development projects.
 
 ![Build Notification](images/wpf-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your WPF application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your WPF application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/wpf-invalid.png)
 

--- a/Extension/WPF-Extension/Template-Studio.md
+++ b/Extension/WPF-Extension/Template-Studio.md
@@ -1,54 +1,54 @@
 ---
 layout: post
 title: Template Studio | Wpf | Syncfusion
-description: Syncfusion provides the Visual Studio Project Templates for the Syncfusion WPF platform to create Syncfusion WPF Application by addiing the required assemblies
+description: Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the Visual Studio Project Templates for the Syncfusion  WPF platform to create Syncfusion  WPF Application by addiing the required assemblies
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 
-# Syncfusion WPF Template Studio
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Template Studio
 
-The WPF Template Studio is a tool Syncfusion provides specifically for building applications using their WPF components. This studio streamlines the development process by including essential Syncfusion components, managing necessary NuGet references, providing predefined namespaces, and generating component render code. It acts as a template studio wizard, making it easier for developers to create WPF applications using Syncfusion components.
+The WPF Template Studio is a tool Syncfusion<sup style="font-size:70%">&reg;</sup>  provides specifically for building applications using their WPF components. This studio streamlines the development process by including essential Syncfusion<sup style="font-size:70%">&reg;</sup>  components, managing necessary NuGet references, providing predefined namespaces, and generating component render code. It acts as a template studio wizard, making it easier for developers to create WPF applications using Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
-I> The Syncfusion WPF Template Studio is available from v23.1.36.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Template Studio is available from v23.1.36.
 
 N> WPF Template Studio works seamlessly with Visual Studio 2017 or later. For the Visual Studio 2015 or lower versions, it is recommended to use a [WPF project template](https://help.syncfusion.com/wpf/visual-studio-integration/create-project).
 
-Create the Syncfusion WPF project using the Visual Studio Project Template by following the provided steps.
+Create the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF project using the Visual Studio Project Template by following the provided steps.
 
 > Check whether the **WPF Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by going to **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 or later, and for Visual Studio 2017 by going to **Tools -> Extensions and Updates -> Installed**. If this extension is not installed, please install the extension by following the steps from the [download and installation](https://help.syncfusion.com/wpf/visual-studio-integration/download-and-installation) help topic.
 
 1.	Open the Visual Studio 2022.
 
-2.	Select one of the following options to create the Syncfusion WPF application
+2.	Select one of the following options to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF application
 
 	**Option 1:**  
-	Choose **Extension -> Syncfusion -> Essential Studio for WPF -> Create New Syncfusion Project…** from the Visual Studio menu.
+	Choose **Extension -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Essential Studio<sup style="font-size:70%">&reg;</sup>  for WPF -> Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** from the Visual Studio menu.
     
-	![Choose Syncfusion WPF Application from Visual Studio new project dialog via Syncfusion menu](Template-Studio-Images/WPF-1.png)
+	![Choose Syncfusion  WPF Application from Visual Studio new project dialog via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Template-Studio-Images/WPF-1.png)
 
-	N> In Visual Studio 2017, you can see the Syncfusion menu directly in the Visual Studio menu.
+	N> In Visual Studio 2017, you can see the Syncfusion<sup style="font-size:70%">&reg;</sup>  menu directly in the Visual Studio menu.
 
 	**Option 2:**   
-	Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Filtering the application type by Syncfusion or typing Syncfusion as a keyword in the search option can help you find the Syncfusion templates for WPF.
+	Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Filtering the application type by Syncfusion<sup style="font-size:70%">&reg;</sup>  or typing Syncfusion<sup style="font-size:70%">&reg;</sup>  as a keyword in the search option can help you find the Syncfusion<sup style="font-size:70%">&reg;</sup>  templates for WPF.
 
-	![Choose Syncfusion WPF Application from Visual Studio new project dialog](Template-Studio-Images/WPF-2.png)
+	![Choose Syncfusion  WPF Application from Visual Studio new project dialog](Template-Studio-Images/WPF-2.png)
 
-3.	Select the Syncfusion WPF Template Studio and click Next.
+3.	Select the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Template Studio and click Next.
 
-	![Choose Syncfusion WPF Application from Visual Studio new project dialog](Template-Studio-Images/WPF-3.png)
+	![Choose Syncfusion  WPF Application from Visual Studio new project dialog](Template-Studio-Images/WPF-3.png)
 
-4.	When you launch the **Syncfusion WPF Template Studio**, you will encounter a configuration wizard that allows you to set up your Syncfusion WPF application. Within this wizard, you will have the option to specify your preferred .NET Core Version or .NET Framework Version, select the desired language(CSharp or Visual Basic), and choose the reference type according to your requirements.
+4.	When you launch the **Syncfusion WPF Template Studio**, you will encounter a configuration wizard that allows you to set up your Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF application. Within this wizard, you will have the option to specify your preferred .NET Core Version or .NET Framework Version, select the desired language(CSharp or Visual Basic), and choose the reference type according to your requirements.
 
 	![Syncfusion WPF project configuration wizard](Template-Studio-Images/WPF-4.png)
 
-	N> The installed location and GAC options will be available only after the Syncfusion Essential WPF setup has been installed. Use the NuGet option instead of installing the Syncfusion Essential WPF setup. Also, the GAC option will not be available when you choose .NET 6.0, .NET 7.0, and .NET 8.0 from the project type option in Visual Studio.
+	N> The installed location and GAC options will be available only after the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF setup has been installed. Use the NuGet option instead of installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WPF setup. Also, the GAC option will not be available when you choose .NET 6.0, .NET 7.0, and .NET 8.0 from the project type option in Visual Studio.
 
 	I> Visual Basic Language support is available in WPF Template Studio starting from version 25.1.35.
 
-5.	Click **Next** or navigate to the **Type** tab, then select the desired Syncfusion WPF application type. When selecting the type of template for your application, you have two options:
+5.	Click **Next** or navigate to the **Type** tab, then select the desired Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF application type. When selecting the type of template for your application, you have two options:
 
 	![Syncfusion WPF project type selection wizard](Template-Studio-Images/WPF-4.png)
 
@@ -58,7 +58,7 @@ Create the Syncfusion WPF project using the Visual Studio Project Template by fo
 
 	**Project type:** Choose this option to select from 4 project types, including Navigation Pane, Blank, Menu Bar, and Ribbon .
 
-6. Click **Next** or navigate to the **Pages** tab to access a list of available Syncfusion WPF components you can add to the application.
+6. Click **Next** or navigate to the **Pages** tab to access a list of available Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF components you can add to the application.
 
 	![Syncfusion WPF pages selection wizard](Template-Studio-Images/WPF-6.png)
 
@@ -80,7 +80,7 @@ In the **Project Details** section, you can modify configurations and project ty
 
 ![Syncfusion WPF project details selection and unselection wizard](Template-Studio-Images/WPF-8.png)
 
-9. Click **Create** to generate the Syncfusion WPF application. Once you've created the project, the relevant Syncfusion NuGet packages will be automatically added to your project for the chosen components. For example, if you add an **DataGrid** control, the corresponding Syncfusion NuGet packages required for that control will be installed.
+9. Click **Create** to generate the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF application. Once you've created the project, the relevant Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages will be automatically added to your project for the chosen components. For example, if you add an **DataGrid** control, the corresponding Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages required for that control will be installed.
 
      ![Syncfusion WPF project created with readme](Template-Studio-Images/WPF-9.png)
 
@@ -151,6 +151,6 @@ In the **Project Details** section, you can modify configurations and project ty
 	>   </tbody>
 	> </table>
 
-13.   Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the 			licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your 	project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in 		Essential Studio.
+13.   Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the 			licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your 	project. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in 		Essential Studio.
 
-       ![Syncfusion license registration required information dialog in Syncfusion WPF project](Template-Studio-Images/Syncfusion-Project-Template-Gallery-9.png)   
+       ![Syncfusion license registration required information dialog in Syncfusion  WPF project](Template-Studio-Images/Syncfusion-Project-Template-Gallery-9.png)   

--- a/Extension/WPF-Extension/Toolbox-Configuration.md
+++ b/Extension/WPF-Extension/Toolbox-Configuration.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Toolbox Configuration | Wpf | Syncfusion
-description: This section provides information regarding all the Syncfusion Essential Studio utilities and its usage
+description: This section provides information regarding all the Syncfusion  Essential Studio  utilities and its usage
 platform: extension
 control: Essential Studio
 documentation: ug
@@ -9,29 +9,29 @@ documentation: ug
 
 # Toolbox Configuration
 
-The Syncfusion Toolbox Installer utility incorporates the Syncfusion WPF components into the Visual Studio .NET toolbox.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox Installer utility incorporates the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF components into the Visual Studio .NET toolbox.
 
-N> Toolbox configuration support is not available for the Visual Studio Express Edition. However, you can manually configure the Syncfusion controls into the Visual Studio Express Toolbox. To do so, refer the [Manual Toolbox Configuration](https://help.syncfusion.com/common/faq/how-to-configure-the-toolbox-of-visual-studio-manually).
+N> Toolbox configuration support is not available for the Visual Studio Express Edition. However, you can manually configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  controls into the Visual Studio Express Toolbox. To do so, refer the [Manual Toolbox Configuration](https://help.syncfusion.com/common/faq/how-to-configure-the-toolbox-of-visual-studio-manually).
 
-If the <b>“Configure Syncfusion Controls in Visual Studio”</b> checkbox is selected from the installer UI while installing the Syncfusion WPF installer, Syncfusion components will be automatically configured in the Visual Studio toolbox.
+If the <b>“Configure Syncfusion<sup style="font-size:70%">&reg;</sup>  Controls in Visual Studio”</b> checkbox is selected from the installer UI while installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF installer, Syncfusion<sup style="font-size:70%">&reg;</sup>  components will be automatically configured in the Visual Studio toolbox.
 
-To add the Syncfusion WPF components via the Syncfusion Toolbox Installer, perform the following steps:
+To add the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF components via the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox Installer, perform the following steps:
 
 1. To launch Toolbox configuration utility, follow either one of the options below:
 
    **Option 1:**   
-   Open the Syncfusion Control Panel, click **Add On and Utilities > Toolbox Installer**.
+   Open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Control Panel, click **Add On and Utilities > Toolbox Installer**.
    
    ![Add On and Utilities](Toolbox-Configuration_images/Toolbox-Configuration_img1.png)
    
    **Option 2:**  
    Click **Syncfusion menu** and choose **Essential Studio for WPF > Toolbox Configuration...** in **Visual Studio**
 
-   ![Toolbox Installer via Syncfusion menu](Toolbox-Configuration_images/Syncfusion_Menu_Toolbox.png)
+   ![Toolbox Installer via Syncfusion  menu](Toolbox-Configuration_images/Syncfusion_Menu_Toolbox.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
-   ![Toolbox Installer via Syncfusion menu](Toolbox-Configuration_images/Syncfusion_Menu_Toolbox_2019.png)
+   ![Toolbox Installer via Syncfusion  menu](Toolbox-Configuration_images/Syncfusion_Menu_Toolbox_2019.png)
 
 2. Toolbox Installer will be opened.
 
@@ -39,17 +39,17 @@ To add the Syncfusion WPF components via the Syncfusion Toolbox Installer, perfo
 
    The following options are available in Toolbox Configuration:
 
-   * Install VS2005 – Configures Framework 2.0 Syncfusion controls in VS 2005 toolbox.
-   * Install VS2008 – Configures Framework 3.5 Syncfusion controls in VS 2008 toolbox.
-   * Install VS2010 – Configures Framework 4.0 Syncfusion controls in VS 2010 toolbox.
-   * Install VS2012 – Configures Framework 4.5 Syncfusion controls in VS 2012 toolbox.
-   * Install VS2013 – Configures Framework 4.5.1 Syncfusion controls in VS 2013 toolbox.
-   * Install VS2015 – Configures Framework 4.6 Syncfusion controls in VS 2015 toolbox.
-   * Install VS2017 – Configures Framework 4.6 Syncfusion controls in VS 2017 toolbox.
-   * Install VS2019 – Configures Framework 4.6 Syncfusion controls in VS 2019 toolbox
-   * Install VS2022 – Configures Framework 4.6 Syncfusion controls in VS 2022 toolbox.
+   * Install VS2005 – Configures Framework 2.0 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2005 toolbox.
+   * Install VS2008 – Configures Framework 3.5 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2008 toolbox.
+   * Install VS2010 – Configures Framework 4.0 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2010 toolbox.
+   * Install VS2012 – Configures Framework 4.5 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2012 toolbox.
+   * Install VS2013 – Configures Framework 4.5.1 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2013 toolbox.
+   * Install VS2015 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2015 toolbox.
+   * Install VS2017 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2017 toolbox.
+   * Install VS2019 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2019 toolbox
+   * Install VS2022 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2022 toolbox.
    
-    N> You can also configure Syncfusion controls from a lower version Framework assembly to higher version of Visual Studio.
+    N> You can also configure Syncfusion<sup style="font-size:70%">&reg;</sup>  controls from a lower version Framework assembly to higher version of Visual Studio.
    
 3. The successful configuration of Toolbox is indicated by an Information message. Click OK.
 
@@ -62,17 +62,17 @@ To add the Syncfusion WPF components via the Syncfusion Toolbox Installer, perfo
    
 ## Configuring toolbox for WPF .NET 5.0 projects
 
-From 2021 Volume 1,Syncfusion started providing toolbox support for the WPF .NET 5.0 framework in Visual Studio. After installing the Syncfusion WPF installer, Syncfusion controls will be automatically configured in the Visual Studio toolbox for WPF.NET 5.0 projects.
+From 2021 Volume 1,Syncfusion started providing toolbox support for the WPF .NET 5.0 framework in Visual Studio. After installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF installer, Syncfusion<sup style="font-size:70%">&reg;</sup>  controls will be automatically configured in the Visual Studio toolbox for WPF.NET 5.0 projects.
 
-N> * Syncfusion included this toolbox support for .NET 5.0 WPF platform from 2021 Volume 1 release version v19.1.0.54 only. 
-* If the project was created with TargetFramework.NET Core 3.1 and then changed to.NET 5.0 after installing the WPF setup, you must restart Visual Studio to see the Syncfusion controls in the Visual Studio Toolbox. 
+N> * Syncfusion<sup style="font-size:70%">&reg;</sup>  included this toolbox support for .NET 5.0 WPF platform from 2021 Volume 1 release version v19.1.0.54 only. 
+* If the project was created with TargetFramework.NET Core 3.1 and then changed to.NET 5.0 after installing the WPF setup, you must restart Visual Studio to see the Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in the Visual Studio Toolbox. 
 * Visual Studio 2019 16.7 Preview 2 and later is required.
 
-### Upgrading the Syncfusion WPF toolbox .NET 5.0 controls without installing the build
+### Upgrading the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF toolbox .NET 5.0 controls without installing the build
 
-You can upgrade the Syncfusion WPF toolbox for .NET 5.0 control with NuGet packages downloaded from [nuget.org](https://www.nuget.org/). Download ["Syncfusion.UI.WPF.NET"](https://www.nuget.org/packages/Syncfusion.UI.WPF.NET/) package from nuget.org in your machine.
+You can upgrade the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF toolbox for .NET 5.0 control with NuGet packages downloaded from [nuget.org](https://www.nuget.org/). Download ["Syncfusion.UI.WPF.NET"](https://www.nuget.org/packages/Syncfusion.UI.WPF.NET/) package from nuget.org in your machine.
 
-Use the following steps to add the Syncfusion WPF controls through Syncfusion NuGet packages:
+Use the following steps to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF controls through Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages:
 
 **step 1:** 
    
@@ -109,19 +109,19 @@ Use the following steps to add the Syncfusion WPF controls through Syncfusion Nu
 	
 **step 3:**
    
-   Update extracted Syncfusion NuGet package path in **value** attribute.
+   Update extracted Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package path in **value** attribute.
 	
    **Example:**
    ![Toolbox Installer](Toolbox-Configuration_images/NET_50_Toolbox_Package_update.png)
 	
 **step 4:**
    
-   Now restart the Visual Studio 2019 to get populate the latest Syncfusion controls in Toolbox.
+   Now restart the Visual Studio 2019 to get populate the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in Toolbox.
 
 
 ## Configuring toolbox for .NET Core 3.1 projects
 
-The Syncfusion NuGet packages must be installed in the WPF .NET Core application before the Syncfusion toolbox can be configured. The corresponding NuGet packages Syncfusion components will be configured in Visual Studio toolbox after installing the Syncfusion NuGet packages in.NET Core application. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages must be installed in the WPF .NET Core application before the Syncfusion<sup style="font-size:70%">&reg;</sup>  toolbox can be configured. The corresponding NuGet packages Syncfusion<sup style="font-size:70%">&reg;</sup>  components will be configured in Visual Studio toolbox after installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in.NET Core application. 
 
-Please refer the documentation [link](../../wpf/installation/install-nuget-packages), to learn more about how to use the Syncfusion components using the Syncfusion NuGet packages in .NET Core application.
+Please refer the documentation [link](../../wpf/installation/install-nuget-packages), to learn more about how to use the Syncfusion<sup style="font-size:70%">&reg;</sup>  components using the Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in .NET Core application.
    

--- a/Extension/WPF-Extension/Troubleshooting.md
+++ b/Extension/WPF-Extension/Troubleshooting.md
@@ -1,35 +1,35 @@
 ---
 layout: post
 title: Troubleshooting | Wpf | Syncfusion
-description: Syncfusion Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in Syncfusion assembly reference, webconfig entries in projects.
+description: Syncfusion  Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in Syncfusion  assembly reference, webconfig entries in projects.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Troubleshoot the project
 
-Troubleshoot the project with the Syncfusion configuration and apply the fix, such as wrong.NET Framework version of a Syncfusion assembly to the project or missing any Syncfusion dependent assembly of a referred assembly. The Syncfusion Troubleshooter can perform the following tasks:
+Troubleshoot the project with the Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration and apply the fix, such as wrong.NET Framework version of a Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly to the project or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter can perform the following tasks:
 
 * Report the Configuration issues.  
 * Apply the solution
 
 ## Report the Configuration issues
 
-The steps below will assist you in using the Syncfusion Troubleshooter by Visual Studio. 
+The steps below will assist you in using the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter by Visual Studio. 
 
 > Check whether the **WPF Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by going to **Tools -> Extensions and Updates -> Installed** for Visual Studio 2017 or lower, and **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 by going to Extensions -> Manage Extensions -> Installed. If this extension not installed, please install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
 
-1. To open Syncfusion Troubleshooter Wizard, follow either one of the options below: 
+1. To open Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter Wizard, follow either one of the options below: 
    
    **Option 1**  
-   Open an existing Syncfusion WPF Application, Click **Syncfusion Menu** and choose **Essential Studio for WPF > Troubleshoot…** in Visual Studio.
+   Open an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF Application, Click **Syncfusion Menu** and choose **Essential Studio for WPF > Troubleshoot…** in Visual Studio.
 
    ![Syncfusion Troubleshooter via Syncfusion menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
-   ![Syncfusion Troubleshooter via Syncfusion menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter_2019.png)
+   ![Syncfusion Troubleshooter via Syncfusion  menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter_2019.png)
 
 
    **Option 2**  
@@ -37,17 +37,17 @@ The steps below will assist you in using the Syncfusion Troubleshooter by Visual
 
    ![Syncfusion Troubleshooter add-in](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img1_2019.png)
 
-2. Analyze the project now, and if any Syncfusion controls project configuration errors are discovered, they will be reported in the Troubleshooter dialog.  If there are no configuration issues with the project, the dialog box will indicate that no modifications are required in the following areas:
+2. Analyze the project now, and if any Syncfusion<sup style="font-size:70%">&reg;</sup>  controls project configuration errors are discovered, they will be reported in the Troubleshooter dialog.  If there are no configuration issues with the project, the dialog box will indicate that no modifications are required in the following areas:
 
-* Syncfusion assembly references.
-* Syncfusion NuGet Packages. 
-* Syncfusion Toolbox Configuration.
+* Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly references.
+* Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages. 
+* Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox Configuration.
 
    ![No configuration changes required dialog box](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img2.png)
 
-I> The Syncfusion Troubleshooter options will be visible only for Syncfusion projects which means the project should contain Syncfusion assemblies or Syncfusion NuGet packages referred.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter options will be visible only for Syncfusion<sup style="font-size:70%">&reg;</sup>  projects which means the project should contain Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages referred.
 
-The Syncfusion Troubleshooter handles the following project configuration issues: 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter handles the following project configuration issues: 
 
 1. Assembly Reference Issues.
 
@@ -57,25 +57,25 @@ The Syncfusion Troubleshooter handles the following project configuration issues
 
 ### Assembly Reference Issues
 
-The Syncfusion Troubleshooter handles the assembly reference issues listed below in Syncfusion Projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter handles the assembly reference issues listed below in Syncfusion<sup style="font-size:70%">&reg;</sup>  Projects. 
 
 1. Dependent assemblies are missing for referred assemblies from project. 
 
-   **For Instance:**  : If “Syncfusion.Chart.WPF” assembly referred in project and “Syncfusion.Shared.WPF” (dependent of Syncfusion.Chart.Base) not referred in project, the Syncfusion Troubleshooter will show dependent assembly missing.
+   **For Instance:**  : If “Syncfusion.Chart.WPF” assembly referred in project and “Syncfusion.Shared.WPF” (dependent of Syncfusion.Chart.Base) not referred in project, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show dependent assembly missing.
 
    ![Dependent assemblies missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img3.png)
 
-2. Syncfusion Troubleshooter compare all Syncfusion assembly’s versions in the same project. If found any Syncfusion assembly version inconsistency, the Syncfusion Troubleshooter will show Syncfusion assemblies version mismatched. 
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter compare all Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly’s versions in the same project. If found any Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version inconsistency, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies version mismatched. 
 
-   **For Instance:**  If “Syncfusion.Tools.WPF” assembly (v17.1450.0.32) referred in project, but other Syncfusion assemblies referred assembly version is v17.1450.0.38. The Syncfusion Troubleshooter will show Syncfusion assembly version mismatched.
+   **For Instance:**  If “Syncfusion.Tools.WPF” assembly (v17.1450.0.32) referred in project, but other Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies referred assembly version is v17.1450.0.38. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version mismatched.
 
    ![Assembly version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img4.png)
 
-3. Framework version mismatching (Syncfusion Assemblies) with project’s .NET Framework version. Find the supported .NET Framework details for Syncfusion assemblies in the following link,
+3. Framework version mismatching (Syncfusion Assemblies) with project’s .NET Framework version. Find the supported .NET Framework details for Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in the following link,
 
    <https://help.syncfusion.com/common/essential-studio/assembly-information#supported-framework-version-for-essential-studio-assemblies> 
 
-   **For Instance:** The.NET Framework of the application is v4.5 and “Syncfusion.Tools.WPF” assembly (v17.1460.0.38 & .NET Framework version 4.6) referred in same application. The Syncfusion Troubleshooter will show Syncfusion assembly .NET Framework version is incompatible with project’s .NET Framework version.
+   **For Instance:** The.NET Framework of the application is v4.5 and “Syncfusion.Tools.WPF” assembly (v17.1460.0.38 & .NET Framework version 4.6) referred in same application. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly .NET Framework version is incompatible with project’s .NET Framework version.
 
    ![Target Framework version of application](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img5.jpg)
 
@@ -83,23 +83,23 @@ The Syncfusion Troubleshooter handles the assembly reference issues listed below
 
 ### NuGet Issues
 
-The Syncfusion Troubleshooter addressed following NuGet package related issues in Syncfusion projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter addressed following NuGet package related issues in Syncfusion<sup style="font-size:70%">&reg;</sup>  projects. 
 
-1. If the application has Syncfusion NuGet packages in multiple versions, then Syncfusion Troubleshooter will show  Syncfusion  NuGet package version is mismatched. 
+1. If the application has Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in multiple versions, then Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show  Syncfusion<sup style="font-size:70%">&reg;</sup>   NuGet package version is mismatched. 
 
-   **For Instance:** Syncfusion WPF platform packages installed multiple version (v16.4.0.54 & v17.1.0.38), Syncfusion Troubleshooter will be shown Syncfusion package version mismatched.
+   **For Instance:** Syncfusion<sup style="font-size:70%">&reg;</sup>  WPF platform packages installed multiple version (v16.4.0.54 & v17.1.0.38), Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  package version mismatched.
  
    ![Syncfusion NuGet Packages version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img7.png)
 
-2. Installed Syncfusion NuGet package’s Framework version is differing from the project’s .NET Framework version.
+2. Installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package’s Framework version is differing from the project’s .NET Framework version.
 
-   **For Instance:** If “Syncfusion.SfBulletGraph.WPF40” NuGet package version(v15.4.0.17 with 4.0 Framework) installed in project, But the project .NET Framework version is 4.5. So, the Syncfusion Troubleshooter will show Syncfusion package Framework version is mismatched.
+   **For Instance:** If “Syncfusion.SfBulletGraph.WPF40” NuGet package version(v15.4.0.17 with 4.0 Framework) installed in project, But the project .NET Framework version is 4.5. So, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  package Framework version is mismatched.
   
    ![Syncfusion NuGet packages Framework version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img8.png)
 
-3. Dependent NuGet package of the installed Syncfusion NuGet packages is missing.
+3. Dependent NuGet package of the installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages is missing.
 
-   **For Instance:** If install Syncfusion.Chart.WPF NuGet package alone in project, Syncfusion Troubleshooter will show the Syncfusion.Chart.Base and other dependent NuGet package missing.
+   **For Instance:** If install Syncfusion.Chart.WPF NuGet package alone in project, Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show the Syncfusion.Chart.Base and other dependent NuGet package missing.
  
    ![Dependent NuGet package missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img9.png)
 
@@ -107,23 +107,23 @@ I> Internet connection is required to restore the missing dependent packages. If
 
 ### Toolbox Configuration Issues
 
-In Syncfusion projects, the Syncfusion Troubleshooter addresses the following Toolbox Configuration issues.
+In Syncfusion<sup style="font-size:70%">&reg;</sup>  projects, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter addresses the following Toolbox Configuration issues.
 
-1. If the project .NET Framework version’s Syncfusion Toolbox is not installed/configured, the Syncfusion Troubleshooter will show Syncfusion Toolbox .NET Framework version is mismatched. 
+1. If the project .NET Framework version’s Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox is not installed/configured, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox .NET Framework version is mismatched. 
 
-   **For Instance:** If latest Syncfusion assembly reference version is v17.1.0.38 but Toolbox assemblies configured v17.1.0.32, the Syncfusion Troubleshooter will show Syncfusion Toolbox version mismatched.
+   **For Instance:** If latest Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference version is v17.1.0.38 but Toolbox assemblies configured v17.1.0.32, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox version mismatched.
  
    ![Syncfusion Toolbox Framework version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img10.png)
 
-2. If the configured version of Syncfusion Toolbox differs from the latest Syncfusion assembly reference version or NuGet package version in the same project, the Syncfusion Troubleshooter will indicate that the Syncfusion Toolbox version is mismatched.
+2. If the configured version of Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox differs from the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference version or NuGet package version in the same project, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will indicate that the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox version is mismatched.
 
-   **For Instance:** If latest Syncfusion assembly reference version is v17.1.0.38 but Toolbox assemblies configured v17.1.0.32, the Syncfusion Troubleshooter will show Syncfusion Toolbox version mismatched.
+   **For Instance:** If latest Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference version is v17.1.0.38 but Toolbox assemblies configured v17.1.0.32, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox version mismatched.
   
    ![Syncfusion Toolbox version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img11.png)
 
 ## Apply the solution
 
-1. After loading the Syncfusion Troubleshooter dialog, check the corresponding check box of the issue to be resolved. Then click the “Fix Issue(s)” button. 
+1. After loading the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter dialog, check the corresponding check box of the issue to be resolved. Then click the “Fix Issue(s)” button. 
 
    ![Syncfusion Troubleshooter wizard with project configuration issues](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img12.png)
 
@@ -131,10 +131,10 @@ In Syncfusion projects, the Syncfusion Troubleshooter addresses the following To
 
    ![Syncfusion Troubleshooter backup dialog](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img13.jpeg)
 
-3. Wait for a while, the Syncfusion Troubleshooter is resolving the selected issues. After the troubleshooting process completed, there will be a status message in the Visual Studio status bar as “Troubleshooting process completed successfully”.
+3. Wait for a while, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter is resolving the selected issues. After the troubleshooting process completed, there will be a status message in the Visual Studio status bar as “Troubleshooting process completed successfully”.
 
    ![Syncfusion Troubleshooter process success status message in visual studio status bar](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img14.jpeg)
 
-4. Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.   
+4. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.   
 
-   ![Syncfusion license registration required information dialog in Syncfusion Troubleshooter](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img15.jpeg)
+   ![Syncfusion license registration required information dialog in Syncfusion  Troubleshooter](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img15.jpeg)

--- a/Extension/WindowsForms-Extension/Add-References.md
+++ b/Extension/WindowsForms-Extension/Add-References.md
@@ -1,57 +1,57 @@
 ---
 layout: post
-title: Add a Syncfusion References| WinForms | Syncfusion
-description: Syncfusion Reference Manger extension is add-in to add the Syncfusion references into the WinForms application
+title: Add a Syncfusion  References| WinForms | Syncfusion
+description: Syncfusion  Reference Manger extension is add-in to add the Syncfusion  references into the WinForms application
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Add Reference for WinForms
 
-Syncfusion Reference Manager is the Visual Studio Add-In for WinForms platform. It adds the Syncfusion assembly reference to the project, either from the GAC location or Essential Studio WinForms installed location. It can also migrate the projects that contain the old versions of the Syncfusion assembly reference to newer or specific versions of the Syncfusion assembly reference. It supports Microsoft Visual Studio 2013 or higher. This Visual Studio extension is included from Essential Studio 2013 Volume 3 release.
+Syncfusion Reference Manager is the Visual Studio Add-In for WinForms platform. It adds the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference to the project, either from the GAC location or Essential Studio<sup style="font-size:70%">&reg;</sup>  WinForms installed location. It can also migrate the projects that contain the old versions of the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference to newer or specific versions of the Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference. It supports Microsoft Visual Studio 2013 or higher. This Visual Studio extension is included from Essential Studio<sup style="font-size:70%">&reg;</sup>  2013 Volume 3 release.
 
-N> This Reference Manager can be applied to a project for Syncfusion assembly versions 10.4.0.71 and later.
+N> This Reference Manager can be applied to a project for Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly versions 10.4.0.71 and later.
 
-Follow the given steps to add the Syncfusion references in Visual Studio:
+Follow the given steps to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio:
 
-> Before use the Syncfusion WinForms Reference Manager, check whether the **WinForms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.If this extension not installed, please install the extension by follow the steps from the [download and installation](https://help.syncfusion.com/windowsforms/visual-studio-integration/vs2019-extensions/download-and-installation/) help topic.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Reference Manager, check whether the **WinForms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.If this extension not installed, please install the extension by follow the steps from the [download and installation](https://help.syncfusion.com/windowsforms/visual-studio-integration/vs2019-extensions/download-and-installation/) help topic.
 
 1. Open a new or existing **WinForms** application.
 
-2. To open Syncfusion Reference Manager Wizard, follow either one of the options below:
+2. To open Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager Wizard, follow either one of the options below:
 
    **Option 1:**  
    Click **Syncfusion Menu** and choose **Essential Studio for WinForms > Add References…** or any other Form in **Visual Studio**.
 
-   ![Syncfusion Reference Manager via Syncfusion Menu](Syncfusion-Reference-Manger_images/Syncfusion_Menu_AddReference.png)
+   ![Syncfusion Reference Manager via Syncfusion  Menu](Syncfusion-Reference-Manger_images/Syncfusion_Menu_AddReference.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
    **Option 2:**  
    Right-click the selected project file from Solution Explorer, then select **Syncfusion Reference Manager…** from **Context Menu**. The following screenshot shows this option in Visual Studio.   
 
    ![Syncfusion Reference Manager add-in](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img1.png)
 
-3. The Syncfusion Reference Manager Wizard that contains the list of Syncfusion WinForms controls that are loaded.
+3. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager Wizard that contains the list of Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms controls that are loaded.
 
    ![Syncfusion Reference Manger Wizard](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img2.png)
 
-   **Platform Selection:** If launched the Syncfusion Reference Manager from Console/Class Library project, Platform selection option will be appeared as option in Syncfusion Reference Manager. Choose the required platform. 
+   **Platform Selection:** If launched the Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager from Console/Class Library project, Platform selection option will be appeared as option in Syncfusion<sup style="font-size:70%">&reg;</sup>  Reference Manager. Choose the required platform. 
 
-   ![Platform selection option in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img3.png)
+   ![Platform selection option in Syncfusion  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img3.png)
 
    **Assembly From:** Choose the assembly location, either from NuGet packages, the build installed location, or by using the GAC location.
 
-   N> The installed location and GAC option will be available only when the Syncfusion Essential Studio Winforms setup has been installed.
+   N> The installed location and GAC option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  Winforms setup has been installed.
 
-   ![Assembly location option in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img4.png)
+   ![Assembly location option in Syncfusion  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img4.png)
 
    N> The GAC option will not be available if you have selected a WinForms (.NET 8.0, .NET 7.0, and .NET 6.0) application in Visual Studio 2022.
 
    **Version:** Choose the build version to add the corresponding version assemblies to the project.
 
-   ![Assembly location option in Syncfusion Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger1-img4.png)
+   ![Assembly location option in Syncfusion  Reference Manger](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger1-img4.png)
 
    
   
@@ -60,15 +60,15 @@ Follow the given steps to add the Syncfusion references in Visual Studio:
 
    ![Syncfusion Reference Manager new assemblies add information dialog](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img5.png)
 
-5. Click **OK**. The listed Syncfusion assemblies are added to project. Then it notifies “Syncfusion assemblies have been added successfully” in Visual Studio status bar.
+5. Click **OK**. The listed Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies are added to project. Then it notifies “Syncfusion assemblies have been added successfully” in Visual Studio status bar.
 
    ![Syncfusion Reference Manager success status in Visual Studio status bar](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img6.png)
 
-6. Then, Syncfusion licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-   ![Syncfusion license registration required information dialog in Syncfusion Reference Manager](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img7.png)
+   ![Syncfusion license registration required information dialog in Syncfusion  Reference Manager](Syncfusion-Reference-Manger_images/Syncfusion-Reference-Manger-img7.png)
 
-N>  Syncfusion provides Reference Manager support for specific .NET Framework, which is shipped (assemblies) in Syncfusion Essential Studio setup. So, if you try to add Syncfusion assemblies in the project and project framework is not supported with selected Syncfusion version assemblies, the dialog appears along with **“Current build v{version} is not supported this framework v{Framework Version}”** message.
+N>  Syncfusion<sup style="font-size:70%">&reg;</sup>  provides Reference Manager support for specific .NET Framework, which is shipped (assemblies) in Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  setup. So, if you try to add Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in the project and project framework is not supported with selected Syncfusion<sup style="font-size:70%">&reg;</sup>  version assemblies, the dialog appears along with **“Current build v{version} is not supported this framework v{Framework Version}”** message.
 
 
 

--- a/Extension/WindowsForms-Extension/Check-for-Updates.md
+++ b/Extension/WindowsForms-Extension/Check-for-Updates.md
@@ -1,17 +1,17 @@
 ---
 layout: post
 title: Check for Updates | WinForms | Syncfusion
-description: Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio release.
+description: Syncfusion  Check for Updates provides Extensions to update most recent version of the Essential Studio  release.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Check for Updates in Syncfusion Essential WindowsForms
+# Check for Updates in Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential<sup style="font-size:70%">&reg;</sup> WindowsForms
 
-Syncfusion provides the check for update extensions to find latest version of essential release was available, if it was available then provide option update most recent version of the Essential Studio release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
+Syncfusion provides the check for update extensions to find latest version of essential release was available, if it was available then provide option update most recent version of the Essential Studio<sup style="font-size:70%">&reg;</sup>  release. So that, you always get the latest features, fixes, and improvements by installing the latest version.
 
-I> The Syncfusion Check for updates is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Check for updates is available from v17.1.0.32.
 
 You can check updates availability in Visual Studio, and then install the update version if required.
 
@@ -19,10 +19,10 @@ You can check updates availability in Visual Studio, and then install the update
 
    ![Syncfusion check for updates menu](Check-for-Updates_images/Check-for-Updates_images-img1.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
    
 2. When there is an update, **Update** dialog box opens.
 
    ![Syncfusion check for updates wizard](Check-for-Updates_images/Check-for-Updates_images-img2.png)
 
-3. You can download the latest Syncfusion Essential Studio from the Syncfusion website by selecting **Download**.
+3. You can download the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  from the Syncfusion<sup style="font-size:70%">&reg;</sup>  website by selecting **Download**.

--- a/Extension/WindowsForms-Extension/Overview.md
+++ b/Extension/WindowsForms-Extension/Overview.md
@@ -1,29 +1,29 @@
 ---
 layout: post
 title: WindowsForms Extension | Extension | Syncfusion
-description: The Syncfusion Windows Extensions provides you with quick access to Project Templates to create or configure the Syncfusion Windows Forms Application
+description: The Syncfusion  Windows Extensions provides you with quick access to Project Templates to create or configure the Syncfusion  Windows Forms Application
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Windows Forms Extension
 
 
-The Syncfusion WinForms Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.The Syncfusion WinForms Extensions supports Microsoft Visual Studio 2010 or higher.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Visual Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.The Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Extensions supports Microsoft Visual Studio 2010 or higher.
 
-N> Syncfusion Extension is published in the Visual Studio Marketplace. Refer to the following link.
+N> Syncfusion<sup style="font-size:70%">&reg;</sup>  Extension is published in the Visual Studio Marketplace. Refer to the following link.
 [https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Windows-Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Windows-Extensions)
 
-I> The Syncfusion WinForms menu option is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms menu option is available from v17.1.0.32.
 
-The Syncfusion provides the following extension supports in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the following extension supports in Visual Studio:
 
-1.	[Syncfusion Windows Forms Project Template](https://help.syncfusion.com/extension/windowsforms-extension/syncfusion-project-templates-for-windows-forms): To create the Syncfusion Windows Forms application by adding the required Syncfusion assemblies and forms.
-2.	[Item Template](https://help.syncfusion.com/extension/windowsforms-extension/syncfusion-item-templates-for-windows-forms): Add predefined Syncfusion items (Forms) and the required Syncfusion assemblies in WinForms Application.
-3.	[Reference Manager](./add-references): To add the required Syncfusion assembly to Windows project reference based on the selected control.
-4.	[Toolbox Configuration](toolbox-configuration): To configure the Syncfusion controls into the Visual Studio .NET toolbox.
-5.	[Troubleshooter](troubleshooting): Troubleshoot the project with the Syncfusion configuration and apply the fix like, wrong Framework Syncfusion assembly added to the project or missing any Syncfusion dependent assembly of a referred assembly.
+1.	[Syncfusion Windows Forms Project Template](https://help.syncfusion.com/extension/windowsforms-extension/syncfusion-project-templates-for-windows-forms): To create the Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and forms.
+2.	[Item Template](https://help.syncfusion.com/extension/windowsforms-extension/syncfusion-item-templates-for-windows-forms): Add predefined Syncfusion<sup style="font-size:70%">&reg;</sup>  items (Forms) and the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in WinForms Application.
+3.	[Reference Manager](./add-references): To add the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly to Windows project reference based on the selected control.
+4.	[Toolbox Configuration](toolbox-configuration): To configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  controls into the Visual Studio .NET toolbox.
+5.	[Troubleshooter](troubleshooting): Troubleshoot the project with the Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration and apply the fix like, wrong Framework Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly added to the project or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly.
 
 **No project selected in Visual Studio**
 
@@ -33,17 +33,17 @@ The Syncfusion provides the following extension supports in Visual Studio:
 
 ![Syncfusion Menu when Selected Microsoft Windows Forms application in Visual Studio](Overview-images/Syncfusion_Menu_OverView2.png)
 
-**Selected Syncfusion Windows Forms application in Visual Studio**
+**Selected Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms application in Visual Studio**
 
 ![Syncfusion Menu when Selected Synfusion Windows Forms application in Visual Studio](Overview-images/Syncfusion_Menu_OverView3.png)
 
-N> From Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.
 
 
-The Syncfusion Windows Forms Visual Studio Extensions are installed along with the following setups,
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms Visual Studio Extensions are installed along with the following setups,
 
-* Essential Studio for Enterprise Edition with the platform Windows Forms
-* Essential Studio for Windows Forms
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Enterprise Edition with the platform Windows Forms
+* Essential Studio<sup style="font-size:70%">&reg;</sup>  for Windows Forms
 
 
 

--- a/Extension/WindowsForms-Extension/Syncfusion-Item-Templates-for-Windows-Forms.md
+++ b/Extension/WindowsForms-Extension/Syncfusion-Item-Templates-for-Windows-Forms.md
@@ -1,57 +1,57 @@
 ---
 layout: post
-title: Syncfusion Item Template | WinForms | Syncfusion
-description: Syncfusion Item Templates provides to add the predefined forms with Syncfusion component in Windows Forms application.
+title: Syncfusion  Item Template | WinForms | Syncfusion
+description: Syncfusion  Item Templates provides to add the predefined forms with Syncfusion  component in Windows Forms application.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Add Syncfusion Components to the WinForms Application
+# Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Components to the WinForms Application
 
-Syncfusion supports Visual Studio Item Templates to add Syncfusion WinForms Components to a WinForms application with Syncfusion WinForms references. 
+Syncfusion supports Visual Studio Item Templates to add Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Components to a WinForms application with Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms references. 
 
-I> The Syncfusion Windows Forms item templates are available from v13.1.0.21.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms item templates are available from v13.1.0.21.
 
-The following steps will guide you in adding the Syncfusion WinForms components to your Visual Studio WinForms application.
+The following steps will guide you in adding the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms components to your Visual Studio WinForms application.
 
 > Check whether the **WinForms Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by going to **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 or later and Visual Studio 2017 or lower by going to **Tools -> Extensions and Updates -> Installed**. If this extension is not installed, please install the extension by following the steps from the [download and installation](https://help.syncfusion.com/windowsforms/visual-studio-integration/download-and-installation) help topic.
 
-## Add Components using Syncfusion Item Template
+## Add Components using Syncfusion<sup style="font-size:70%">&reg;</sup>  Item Template
 
 1.	Open a new or existing WinForms application.
 
 	**Option 1:**
 
-2.	From the **Solution Explorer, right-click** on the WinForms application. Choose **Add Syncfusion Item...**.
+2.	From the **Solution Explorer, right-click** on the WinForms application. Choose **Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Item...**.
 
-	![Choose Add Syncfusion Item option from right click project](Item-Template-images/Add-syncfusion-item.png)
+	![Choose Add Syncfusion  Item option from right click project](Item-Template-images/Add-syncfusion-item.png)
 
 	**Option 2:**
 
-3.	Click **Extensions > Essential Studio for WinForms > Add Syncfusion Item…** in Visual Studio.
+3.	Click **Extensions > Essential Studio<sup style="font-size:70%">&reg;</sup>  for WinForms > Add Syncfusion<sup style="font-size:70%">&reg;</sup>  Item…** in Visual Studio.
 
-	![Choose Add Syncfusion Item option from menu](Item-Template-images/Add-item.png)
+	![Choose Add Syncfusion  Item option from menu](Item-Template-images/Add-item.png)
 
 
-4.	The Syncfusion WinForms Item Template wizard will be launched as follows.
+4.	The Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Item Template wizard will be launched as follows.
 
 	![Syncfusion WinForms Item template Components](Item-Template-images/Add-syncfusion-ui.png)
 
 5.	Select the WinForms Components from the Component list within your WinForms Item Template. The features associated with the selected Component will be presented. From here, 		choose the specific features that are essential for your project.
 
-6.	Choose an assembly reference option such as GAC location, Essential Studio installed location, or NuGet packages to specify where the required Syncfusion assemblies 	are added to the project.
+6.	Choose an assembly reference option such as GAC location, Essential Studio<sup style="font-size:70%">&reg;</sup>  installed location, or NuGet packages to specify where the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies 	are added to the project.
 
-	N> If the Syncfusion Essential WindowsForm build is installed, the Installed location and GAC options will be enabled. Without installing the Syncfusion Essential WindowsForm setup, use the NuGet option. The GAC option will not be available when using the Syncfusion WinForms Components in a .NET Core application. The Version drop-down lists the installed WinForms versions.
+	N> If the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WindowsForm build is installed, the Installed location and GAC options will be enabled. Without installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WindowsForm setup, use the NuGet option. The GAC option will not be available when using the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Components in a .NET Core application. The Version drop-down lists the installed WinForms versions.
 
 7.  Click **Add**, and a pop-up will appear providing information about adding Component **files** and **NuGet/Assemblies** details.
 
 	![Syncfusion WinForms Item template details](Item-Template-images/Add-syncfusion-item-3.png)	
 
-8.	Click **OK** to incorporate the chosen Components into the WinForms application, along with the necessary Syncfusion assemblies.
+8.	Click **OK** to incorporate the chosen Components into the WinForms application, along with the necessary Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies.
 
 	![Syncfusion WinForms Item template Gallery](Item-Template-images/Add-syncfusion-item-details.png)
 
-9.	Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the 			licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/			licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to 		your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post 	 for understanding the licensing changes introduced in Essential Studio.
+9.	Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the 			licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/			licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to 		your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post 	 for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
     ![Syncfusion WinForms Item template Gallery](Item-Template-images/Syncfusion-Item-Template-Gallery-7.png)

--- a/Extension/WindowsForms-Extension/Syncfusion-Notifications.md
+++ b/Extension/WindowsForms-Extension/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications | WinForms | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in Windows Forms applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in Windows Forms applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> Winforms**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Winforms**
 
 ![Option Page](images/winforms-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your Windows Forms application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your Windows Forms application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/winforms-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/winforms-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio Windows,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your Windows Forms development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio<sup style="font-size:70%">&reg;</sup> Windows,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your Windows Forms development projects.
 
 ![Build Notification](images/winforms-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your Windows Forms application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your Windows Forms application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/winforms-invalid.png)
 

--- a/Extension/WindowsForms-Extension/Syncfusion-Project-Templates-for-Windows-Forms.md
+++ b/Extension/WindowsForms-Extension/Syncfusion-Project-Templates-for-Windows-Forms.md
@@ -1,51 +1,51 @@
 ---
 layout: post
 title: Project Templates for Windows Forms | WinForms | Syncfusion
-description: Syncfusion Project Templates Extension creates the Syncfusion Windows Forms Application by adding the required assemblies.
+description: Syncfusion  Project Templates Extension creates the Syncfusion  Windows Forms Application by adding the required assemblies.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Create WinForms application
 
-Syncfusion provides the Visual Studio Project Template for the Syncfusion WinForms platform to create the Syncfusion WinForms Application by adding the required Syncfusion assemblies and forms. 
+Syncfusion provides the Visual Studio Project Template for the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms platform to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies and forms. 
 
-I> The Syncfusion Windows Forms templates are available from v14.3.0.49. 
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms templates are available from v14.3.0.49. 
 
 >WinForms Project Template works seamlessly with Visual Studio 2015 or lower. For the Visual Studio 2017 or later versions, it is recommended to use a [WinForms Template Studio](https://help.syncfusion.com/windowsforms/visual-studio-integration/template-studio).
 
-Use the following steps to create the Syncfusion Windows Forms project through the Visual Studio Project Template. 
+Use the following steps to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms project through the Visual Studio Project Template. 
 
 > Check whether the **WinForms Extensions - Syncfusion** are installed or not in Visual Studio 2015 or lower by going to **Tools -> Extensions and Updates -> Installed**. If this extension not installed, please install the extension by follow the steps from the [download and installation](https://help.syncfusion.com/windowsforms/visual-studio-integration/download-and-installation) help topic.
 
-1. To create a Syncfusion Windows Forms project, follow either one of the options below:  
+1. To create a Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms project, follow either one of the options below:  
     
    **Option 1:**  
-   Click **Syncfusion Menu** and choose **Essential Studio for WinForms > Create New Syncfusion Project…**  in **Visual Studio**.
+   Click **Syncfusion Menu** and choose **Essential Studio for WinForms > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…**  in **Visual Studio**.
 
-   ![Choose Syncfusion Windows Forms Application via Syncfusion menu](Project-Template-images\Syncfusion-menu.png)
+   ![Choose Syncfusion  Windows Forms Application via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Project-Template-images\Syncfusion-menu.png)
 
-   N> In Visual Studio 2015 or lower, you can see the Syncfusion menu directly in the Visual Studio menu.
+   N> In Visual Studio 2015 or lower, you can see the Syncfusion<sup style="font-size:70%">&reg;</sup>  menu directly in the Visual Studio menu.
 
    **Option 2:**  
-    Choose **File -> New -> Project**. Opens a new dialog to create a new project. You can obtain the templates provided by Syncfusion for WinForms by filtering the project type with Syncfusion or by using the Syncfusion keyword in the search option
+    Choose **File -> New -> Project**. Opens a new dialog to create a new project. You can obtain the templates provided by Syncfusion<sup style="font-size:70%">&reg;</sup>  for WinForms by filtering the project type with Syncfusion<sup style="font-size:70%">&reg;</sup>  or by using the Syncfusion<sup style="font-size:70%">&reg;</sup>  keyword in the search option
 
-   ![Choose Syncfusion Windows Forms Application from Visual Studio new project dialog](Project-Template-images\Syncfusion-Project-Template-Gallery2019-1.png)
+   ![Choose Syncfusion  Windows Forms Application from Visual Studio new project dialog](Project-Template-images\Syncfusion-Project-Template-Gallery2019-1.png)
 
-   In Visual Studio 2015 or lower, Select File > New > Project and navigate to Syncfusion > Windows > Syncfusion Windows Forms Application in Visual Studio.
+   In Visual Studio 2015 or lower, Select File > New > Project and navigate to Syncfusion<sup style="font-size:70%">&reg;</sup>  > Windows > Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms Application in Visual Studio.
 
-   ![Choose Syncfusion Windows Forms Application from Visual Studio new project dialog](Project-Template-images\Syncfusion-Project-Template-Gallery-1.png)
+   ![Choose Syncfusion  Windows Forms Application from Visual Studio new project dialog](Project-Template-images\Syncfusion-Project-Template-Gallery-1.png)
 
 2. Name the **Project**, choose the destination location when required, select the project type, and choose the reference from where the assembly is added to the project then click **OK**.  
 
-   N> Minimum target Framework is 3.5 for Syncfusion WinForms project templates. 
+   N> Minimum target Framework is 3.5 for Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms project templates. 
 
-3. Choose the options to configure the Syncfusion WinForms Application by using the following Project Configuration Wizard.  
+3. Choose the options to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Application by using the following Project Configuration Wizard.  
   
    ![Syncfusion Windows Forms project configuration wizard](Project-Template-images\Syncfusion-Project-Template-Gallery2019-2.png)
 
-   In Visual Studio 2015 or lower, Syncfusion Windows Forms Application project configuration wizard.
+   In Visual Studio 2015 or lower, Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms Application project configuration wizard.
 
    ![Syncfusion Windows Forms project configuration wizard](Project-Template-images\Syncfusion-Project-Template-Gallery-2.png)
                                                      
@@ -55,17 +55,17 @@ Use the following steps to create the Syncfusion Windows Forms project through t
 
    **Language:** Select the language, either CSharp or VB.
 
-   **Reference From:** Choose the assembly location such as NuGet, GAC Location, or Essential Studio installed location, from where the assembly is added to the project.
+   **Reference From:** Choose the assembly location such as NuGet, GAC Location, or Essential Studio<sup style="font-size:70%">&reg;</sup>  installed location, from where the assembly is added to the project.
 
-   N> Installed location and GAC option will be available only when the Syncfusion Essential Windows Forms setup has been installed. You can use NuGet option without installing the Syncfusion Essential Windows Forms setup.
+   N> Installed location and GAC option will be available only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Windows Forms setup has been installed. You can use NuGet option without installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Windows Forms setup.
 
    **Installed ES Build Version:** Choose the build version to add the corresponding version assemblies to the project.
 
-   N> Installed ES build version option will be available only when you install the Syncfusion Essential Windows Forms setup and choose the assembly location as Installed Location or GAC.
+   N> Installed ES build version option will be available only when you install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Windows Forms setup and choose the assembly location as Installed Location or GAC.
 
    **Select Window:** Choose the window as required for application.
       
-4. After choosing above project configuration options in the Project Configuration Wizard, click the create button then Syncfusion WinForms project is created with the necessary XAML files and required Syncfusion WinForms assemblies/NuGet packages. 
+4. After choosing above project configuration options in the Project Configuration Wizard, click the create button then Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms project is created with the necessary XAML files and required Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms assemblies/NuGet packages. 
 
    ![Syncfusion Windows Forms project created with required references](Project-Template-images\Syncfusion-Project-Template-Gallery-6.png)
 
@@ -73,6 +73,6 @@ Use the following steps to create the Syncfusion Windows Forms project through t
 
    ![Syncfusion Windows Forms project created with readme](Project-Template-images\Syncfusion-Project-Template-Gallery-9.PNG)
 
-5. Then, the Syncfusion licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post to learn more the licensing changes introduced in Essential Studio.
+5. Then, the Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post to learn more the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-   ![Syncfusion license registration required information dialog in Syncfusion Windows Forms Project](Project-Template-images\Syncfusion-Project-Template-Gallery-8.png)   
+   ![Syncfusion license registration required information dialog in Syncfusion  Windows Forms Project](Project-Template-images\Syncfusion-Project-Template-Gallery-8.png)   

--- a/Extension/WindowsForms-Extension/Template-Studio.md
+++ b/Extension/WindowsForms-Extension/Template-Studio.md
@@ -1,54 +1,54 @@
 ---
 layout: post
 title: Template Studio | WinForms | Syncfusion
-description: Visual Studio Project Templates for the Syncfusion WinForms platform to create Syncfusion WinForms Application by addiing the required assemblies
+description: Visual Studio Project Templates for the Syncfusion  WinForms platform to create Syncfusion  WinForms Application by addiing the required assemblies
 platform: windowsforms
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 
-# Syncfusion WinForms Template Studio
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Template Studio
 
-The WinForms Template Studio by Syncfusion is a specialized tool for constructing applications with their WinForms components. This studio simplifies development by incorporating crucial Syncfusion components, handling required NuGet references, offering preset namespaces, and creating component render code. Acting as a wizard, it facilitates the creation of WinForms applications using Syncfusion components, streamlining the process for developers.
+The WinForms Template Studio by Syncfusion<sup style="font-size:70%">&reg;</sup>  is a specialized tool for constructing applications with their WinForms components. This studio simplifies development by incorporating crucial Syncfusion<sup style="font-size:70%">&reg;</sup>  components, handling required NuGet references, offering preset namespaces, and creating component render code. Acting as a wizard, it facilitates the creation of WinForms applications using Syncfusion<sup style="font-size:70%">&reg;</sup>  components, streamlining the process for developers.
 
-I> The Syncfusion WinForms Template Studio is available from v24.1.41.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Template Studio is available from v24.1.41.
 
 N> WinForms Template Studio is compatible with Visual Studio 2022, Visual Studio 2019, and Visual Studio 2017. For the Visual Studio 2015 or lower versions, it is recommended to use a [WinForms project template](https://help.syncfusion.com/windowsforms/visual-studio-integration/create-project).
 
-Create the Syncfusion WinForms project using the Visual Studio Project Template by following the provided steps.
+Create the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms project using the Visual Studio Project Template by following the provided steps.
 
 > Check whether the **WinForms Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by going to **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 or later, and for Visual Studio 2017 by going to **Tools -> Extensions and Updates -> Installed**. If this extension is not installed, please install the extension by following the steps from the [download and installation](https://help.syncfusion.com/windowsforms/visual-studio-integration/download-and-installation) help topic.
 
 1.	Open the Visual Studio 2022.
 
-2.	Select one of the following options to create the Syncfusion WinForms application
+2.	Select one of the following options to create the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms application
 
 	**Option 1:**  
-	Choose **Extension -> Syncfusion -> Essential Studio for WinForms -> Create New Syncfusion Project…** from the Visual Studio menu.
+	Choose **Extension -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Essential Studio<sup style="font-size:70%">&reg;</sup>  for WinForms -> Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** from the Visual Studio menu.
     
-	![Choose Syncfusion WinForms Application from Visual Studio new project dialog via Syncfusion menu](Template-Studio-Images/WF-1.png)
+	![Choose Syncfusion  WinForms Application from Visual Studio new project dialog via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Template-Studio-Images/WF-1.png)
 
-	N> In Visual Studio 2017, you can see the Syncfusion menu directly in the Visual Studio menu.
+	N> In Visual Studio 2017, you can see the Syncfusion<sup style="font-size:70%">&reg;</sup>  menu directly in the Visual Studio menu.
 
 	**Option 2:**   
-	Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Filtering the application type by Syncfusion or typing Syncfusion as a keyword in the search option can help you find the Syncfusion templates for WinForms.
+	Choose **File -> New -> Project** from the menu. This launches a new dialogue for creating a new application. Filtering the application type by Syncfusion<sup style="font-size:70%">&reg;</sup>  or typing Syncfusion<sup style="font-size:70%">&reg;</sup>  as a keyword in the search option can help you find the Syncfusion<sup style="font-size:70%">&reg;</sup>  templates for WinForms.
 
-	![Choose Syncfusion WinForms Application from Visual Studio new project dialog](Template-Studio-Images/WF-2.png)
+	![Choose Syncfusion  WinForms Application from Visual Studio new project dialog](Template-Studio-Images/WF-2.png)
 
 3.	Select the **Syncfusion WinForms Template Studio** and click Next.
 
-	![Choose Syncfusion WinForms Application from Visual Studio new project dialog](Template-Studio-Images/WF-3.png)
+	![Choose Syncfusion  WinForms Application from Visual Studio new project dialog](Template-Studio-Images/WF-3.png)
 
-4.	When you launch the **Syncfusion WinForms Template Studio**, you will encounter a configuration wizard that allows you to set up your Syncfusion WinForms application. Within this wizard, you will have the option to specify your preferred .NET Core Version or .NET Framework Version, select the desired language(CSharp or Visual Basic), and choose the reference type according to your requirements.
+4.	When you launch the **Syncfusion WinForms Template Studio**, you will encounter a configuration wizard that allows you to set up your Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms application. Within this wizard, you will have the option to specify your preferred .NET Core Version or .NET Framework Version, select the desired language(CSharp or Visual Basic), and choose the reference type according to your requirements.
 
 	![Syncfusion WinForms project configuration wizard](Template-Studio-Images/WF-5.png)
 
-	N> The installed location and GAC options will be available only after the Syncfusion Essential WinForms setup has been installed. Use the NuGet option instead of installing the Syncfusion Essential WinForms setup. Also, the GAC option will not be available when you choose .NET 6.0, .NET 7.0, and .NET 8.0 from the project type option in Visual Studio.
+	N> The installed location and GAC options will be available only after the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WinForms setup has been installed. Use the NuGet option instead of installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential WinForms setup. Also, the GAC option will not be available when you choose .NET 6.0, .NET 7.0, and .NET 8.0 from the project type option in Visual Studio.
 
 	I> Visual Basic Language support is available in WinForms Template Studio starting from version 25.1.35.
 
-5.  Navigate to the **Type** tab and choose the Syncfusion WinForms application type you want. When selecting the type of template for your application, you have two options:
+5.  Navigate to the **Type** tab and choose the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms application type you want. When selecting the type of template for your application, you have two options:
 
 	![Syncfusion WinForms project type selection wizard](Template-Studio-Images/WF-4.png)
 
@@ -58,7 +58,7 @@ Create the Syncfusion WinForms project using the Visual Studio Project Template 
 
 	**Project type:** Choose this option to select from 4 project types, including Blank, Menu Bar, Ribbon, and Tabbed Form.
 
-6. Click **Next** or navigate to the **Pages** tab to access a list of available Syncfusion WinForms components you can add to the application.
+6. Click **Next** or navigate to the **Pages** tab to access a list of available Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms components you can add to the application.
 
 	![Syncfusion WinForms pages selection wizard](Template-Studio-Images/WF-6.png)
 
@@ -82,7 +82,7 @@ Create the Syncfusion WinForms project using the Visual Studio Project Template 
 
      ![Syncfusion WinForms project details selection and unselection wizard](Template-Studio-Images/WF-8.png)
 
-9.	Click **Create** to generate the Syncfusion WinForms application. Once you've created the project, the relevant Syncfusion NuGet packages will be automatically added to your project for the chosen components. For example, if you add an **DataGrid** control, the corresponding Syncfusion NuGet packages required for that control will be installed.
+9.	Click **Create** to generate the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms application. Once you've created the project, the relevant Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages will be automatically added to your project for the chosen components. For example, if you add an **DataGrid** control, the corresponding Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages required for that control will be installed.
 
 	![Syncfusion WinForms project created with readme](Template-Studio-Images/WF-9.png)
 
@@ -152,6 +152,6 @@ Here's a simple explanation:
 	>   </tbody>
 	> </table>
 
-13.	If you install the trial setup or NuGet packages from nuget.org, you must register the Syncfusion license key to your application since Syncfusion introduced the licensing system from the 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in 	Essential Studio.
+13.	If you install the trial setup or NuGet packages from nuget.org, you must register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from the 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key) to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your application. Refer to this [blog](https://www.syncfusion.com/blogs/post/whats-new-in-2018-volume-2.aspx) post for understanding the licensing changes introduced in 	Essential Studio<sup style="font-size:70%">&reg;</sup>.
 
-	![Syncfusion license registration required information dialog in Syncfusion WinForms project](Template-Studio-Images/Syncfusion-Project-Template-Gallery-8.png)   
+	![Syncfusion license registration required information dialog in Syncfusion  WinForms project](Template-Studio-Images/Syncfusion-Project-Template-Gallery-8.png)   

--- a/Extension/WindowsForms-Extension/Toolbox-Configuration.md
+++ b/Extension/WindowsForms-Extension/Toolbox-Configuration.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Toolbox Configuration | WinForms | Syncfusion
-description: This section provides information regarding all the Syncfusion Essential Studio utilities and its usage
+description: This section provides information regarding all the Syncfusion  Essential Studio  utilities and its usage
 platform: extension
 control: Essential Studio
 documentation: ug
@@ -9,27 +9,27 @@ documentation: ug
 
 # Toolbox Configuration
 
-The Syncfusion Toolbox utility adds the Syncfusion WinForms controls into the Visual Studio .NET toolbox.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox utility adds the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms controls into the Visual Studio .NET toolbox.
 
-N> Visual Studio Express Edition does not support toolbox configuration. However, you can manually configure the Syncfusion controls into the Visual Studio Express Toolbox. To do so, refer the [Manual Toolbox Configuration](https://help.syncfusion.com/common/faq/how-to-configure-the-toolbox-of-visual-studio-manually).
+N> Visual Studio Express Edition does not support toolbox configuration. However, you can manually configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  controls into the Visual Studio Express Toolbox. To do so, refer the [Manual Toolbox Configuration](https://help.syncfusion.com/common/faq/how-to-configure-the-toolbox-of-visual-studio-manually).
 
-Syncfusion controls will be automatically configured in the Visual Studio toolbox, while installing the Syncfusion Windows Forms installer, if the <b>“Configure Syncfusion Controls in Visual Studio”</b> checkbox is selected from installer UI.
+Syncfusion controls will be automatically configured in the Visual Studio toolbox, while installing the Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows Forms installer, if the <b>“Configure Syncfusion<sup style="font-size:70%">&reg;</sup>  Controls in Visual Studio”</b> checkbox is selected from installer UI.
 
-Use the following steps to add the Syncfusion WinForms controls through the Syncfusion Toolbox Installer:
+Use the following steps to add the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms controls through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox Installer:
 
 1. To launch Toolbox configuration utility, follow either one of the options below:
 
    **Option 1:**   
-   To open the Syncfusion Control Panel, click **Add On and Utilities > Toolbox Installer**.
+   To open the Syncfusion<sup style="font-size:70%">&reg;</sup>  Control Panel, click **Add On and Utilities > Toolbox Installer**.
    
    ![Add On and Utilities](Toolbox-Configuration_images/Toolbox-Configuration_img1.png)
    
    **Option 2:**  
    Click **Syncfusion menu** and choose **Essential Studio for WinForms > Toolbox Configuration...** in **Visual Studio**.
 
-   ![Toolbox Installer via Syncfusion menu](Toolbox-Configuration_images/Syncfusion_Menu_Toolbox.png)
+   ![Toolbox Installer via Syncfusion  menu](Toolbox-Configuration_images/Syncfusion_Menu_Toolbox.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
 2. Toolbox Installer will be opened.
 
@@ -37,17 +37,17 @@ Use the following steps to add the Syncfusion WinForms controls through the Sync
 
    The following options are available in Toolbox Configuration:
 
-   * Install VS2005 – Configures Framework 2.0 Syncfusion controls in VS 2005 toolbox.
-   * Install VS2008 – Configures Framework 3.5 Syncfusion controls in VS 2008 toolbox.
-   * Install VS2010 – Configures Framework 4.0 Syncfusion controls in VS 2010 toolbox.
-   * Install VS2012 – Configures Framework 4.5 Syncfusion controls in VS 2012 toolbox.
-   * Install VS2013 – Configures Framework 4.5.1 Syncfusion controls in VS 2013 toolbox.
-   * Install VS2015 – Configures Framework 4.6 Syncfusion controls in VS 2015 toolbox.
-   * Install VS2017 – Configures Framework 4.6 Syncfusion controls in VS 2017 toolbox.
-   * Install VS2019 – Configures Framework 4.6 Syncfusion controls in VS 2019 toolbox
-   * Install VS2022 – Configures Framework 4.6 Syncfusion controls in VS 2019 toolbox
+   * Install VS2005 – Configures Framework 2.0 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2005 toolbox.
+   * Install VS2008 – Configures Framework 3.5 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2008 toolbox.
+   * Install VS2010 – Configures Framework 4.0 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2010 toolbox.
+   * Install VS2012 – Configures Framework 4.5 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2012 toolbox.
+   * Install VS2013 – Configures Framework 4.5.1 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2013 toolbox.
+   * Install VS2015 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2015 toolbox.
+   * Install VS2017 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2017 toolbox.
+   * Install VS2019 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2019 toolbox
+   * Install VS2022 – Configures Framework 4.6 Syncfusion<sup style="font-size:70%">&reg;</sup>  controls in VS 2019 toolbox
    
-    N> You can also configure Syncfusion controls from a lower version Framework assembly to higher version of Visual Studio.
+    N> You can also configure Syncfusion<sup style="font-size:70%">&reg;</sup>  controls from a lower version Framework assembly to higher version of Visual Studio.
    
 3. The successful configuration of Toolbox is indicated by an Information message. Click **OK**.
 

--- a/Extension/WindowsForms-Extension/Troubleshooting.md
+++ b/Extension/WindowsForms-Extension/Troubleshooting.md
@@ -1,50 +1,50 @@
 ---
 layout: post
 title: Troubleshooting | WinForms | Syncfusion
-description: Syncfusion Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in Syncfusion assembly reference, webconfig entries in projects.
+description: Syncfusion  Troubleshooter is Visual Studio extension to troubleshoot the configuration issues in Syncfusion  assembly reference, webconfig entries in projects.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Troubleshoot the project
 
-Troubleshoot the project with the Syncfusion configuration and apply the fix, such as adding a Syncfusion assembly to the project with the wrong .NET Framework version or missing any Syncfusion dependent assembly of a referred assembly. The Syncfusion Troubleshooter is capable of performing the following tasks:
+Troubleshoot the project with the Syncfusion<sup style="font-size:70%">&reg;</sup>  configuration and apply the fix, such as adding a Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly to the project with the wrong .NET Framework version or missing any Syncfusion<sup style="font-size:70%">&reg;</sup>  dependent assembly of a referred assembly. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter is capable of performing the following tasks:
 
 * Report the Configuration issues.  
 * Apply the solution.
 
 ## Report the Configuration issues
 
-The following steps help you to utilize the Syncfusion Troubleshooter by Visual Studio. 
+The following steps help you to utilize the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter by Visual Studio. 
 
-> Before use the Syncfusion Troubleshooter for WinForms, check whether the **WinForms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.If this extension not installed, please install the extension by follow the steps from the [download and installation](https://help.syncfusion.com/windowsforms/visual-studio-integration/vs2019-extensions/download-and-installation/) help topic.
+> Before use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter for WinForms, check whether the **WinForms Extensions - Syncfusion** installed or not in Visual Studio Extension Manager by clicking on the Tools -> Extensions and Updates -> Installed for Visual Studio 2017 or lower and for Visual Studio 2019 by clicking on the Extensions -> Manage Extensions -> Installed.If this extension not installed, please install the extension by follow the steps from the [download and installation](https://help.syncfusion.com/windowsforms/visual-studio-integration/vs2019-extensions/download-and-installation/) help topic.
 
-1. To open Syncfusion Troubleshooter Wizard, follow either one of the options below: 
+1. To open Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter Wizard, follow either one of the options below: 
    
    **Option 1:**  
-   Open an existing Syncfusion WinForms Application, Click **Syncfusion Menu** and choose **Essential Studio for WinForms > Troubleshoot…** in Visual Studio.
+   Open an existing Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms Application, Click **Syncfusion Menu** and choose **Essential Studio for WinForms > Troubleshoot…** in Visual Studio.
 
-   ![Syncfusion Troubleshooter via Syncfusion menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter.png)
+   ![Syncfusion Troubleshooter via Syncfusion  menu](SyncfusionTroubleshooter_images/Syncfusion_Menu_Troubleshooter.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
    **Option 2:**  
-   Right-click the Project file in Solution Explorer, then select the command Syncfusion Troubleshooter…
+   Right-click the Project file in Solution Explorer, then select the command Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter…
 
    ![Syncfusion Troubleshooter add-in](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img1.jpeg)
 
-2. Analyze the project now, and if any Syncfusion controls project configuration errors are discovered, they will be reported in the Troubleshooter dialog.  If there are no configuration issues with the project, the dialog box will indicate that no modifications are required in the following areas:
+2. Analyze the project now, and if any Syncfusion<sup style="font-size:70%">&reg;</sup>  controls project configuration errors are discovered, they will be reported in the Troubleshooter dialog.  If there are no configuration issues with the project, the dialog box will indicate that no modifications are required in the following areas:
 
-* Syncfusion assembly references.
-* Syncfusion NuGet Packages. 
-* Syncfusion Toolbox Configuration.
+* Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly references.
+* Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages. 
+* Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox Configuration.
 
    ![No configuration changes required dialog box](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img2.png)
 
-I> The Syncfusion Troubleshooter command will be visible only for Syncfusion projects that means Syncfusion assemblies or Syncfusion NuGet packages should be referred in to the project.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter command will be visible only for Syncfusion<sup style="font-size:70%">&reg;</sup>  projects that means Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages should be referred in to the project.
 
-The Syncfusion Troubleshooter handles the following project configuration issues: 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter handles the following project configuration issues: 
 
 1. Assembly Reference Issues.
 
@@ -54,25 +54,25 @@ The Syncfusion Troubleshooter handles the following project configuration issues
 
 ### Assembly Reference Issues
 
-The Syncfusion Troubleshooter deals with the following assembly reference issues in Syncfusion Projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter deals with the following assembly reference issues in Syncfusion<sup style="font-size:70%">&reg;</sup>  Projects. 
 
 1. Dependent assemblies are missing for referred assemblies from project. 
 
-   **For Instance:**  If “Syncfusion.Grid.Windows” assembly referred in project and “Syncfusion.Shared.Windows” (dependent of Syncfusion.Grid.Windows) not referred in project, the Syncfusion Troubleshooter will show dependent assembly missing.
+   **For Instance:**  If “Syncfusion.Grid.Windows” assembly referred in project and “Syncfusion.Shared.Windows” (dependent of Syncfusion.Grid.Windows) not referred in project, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show dependent assembly missing.
 
    ![Dependent assemblies missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img3.png)
 
-2. Syncfusion assembly version mismatched. Compare to all Syncfusion assembly’s versions in the same project. If found any Syncfusion assembly version inconsistency, the Syncfusion Troubleshooter will show Syncfusion assemblies version mismatched. 
+2. Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version mismatched. Compare to all Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly’s versions in the same project. If found any Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version inconsistency, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies version mismatched. 
 
-   **For Instance:**  If “Syncfusion.Tools.Windows” assembly (v15.2450.0.40) referred in project, but other Syncfusion assemblies referred assembly version is v15.2450.0.43. Syncfusion Troubleshooter will be shown Syncfusion assembly version mismatched.
+   **For Instance:**  If “Syncfusion.Tools.Windows” assembly (v15.2450.0.40) referred in project, but other Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies referred assembly version is v15.2450.0.43. Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly version mismatched.
 
    ![Assembly version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img4.png)
 
-3. Framework version mismatching (Syncfusion Assemblies) with project’s .NET Framework version. Find the supported .NET Framework details for Syncfusion assemblies in the following link,
+3. Framework version mismatching (Syncfusion Assemblies) with project’s .NET Framework version. Find the supported .NET Framework details for Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies in the following link,
 
    <https://help.syncfusion.com/common/essential-studio/assembly-information#supported-framework-version-for-essential-studio-assemblies> 
 
-   **For Instance:** The.NET Framework of the application is v4.5 and “Syncfusion.Tools.Windows” assembly (v17.1460.0.38 & .NET Framework version 4.6) referred in same application. The Syncfusion Troubleshooter will show Syncfusion assembly .NET Framework version is incompatible with project’s .NET Framework version.
+   **For Instance:** The.NET Framework of the application is v4.5 and “Syncfusion.Tools.Windows” assembly (v17.1460.0.38 & .NET Framework version 4.6) referred in same application. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly .NET Framework version is incompatible with project’s .NET Framework version.
 
    ![Target Framework version of application](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img5.png)
 
@@ -80,23 +80,23 @@ The Syncfusion Troubleshooter deals with the following assembly reference issues
 
 ### NuGet Issues
 
-The Syncfusion Troubleshooter deals with the following NuGet package related issues in Syncfusion projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter deals with the following NuGet package related issues in Syncfusion<sup style="font-size:70%">&reg;</sup>  projects. 
 
-1. Multiple versions of Syncfusion NuGet Packages are installed. If Syncfusion NuGet Package version is differ from other Syncfusion NuGet Package version, the Syncfusion Troubleshooter will show Syncfusion NuGet package version is mismatched. 
+1. Multiple versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Packages are installed. If Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package version is differ from other Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package version, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package version is mismatched. 
 
-   **For Instance:** Syncfusion WinForms platform packages installed multiple version (v16.4.0.54 & v17.1.0.38), Syncfusion Troubleshooter will be shown Syncfusion package version mismatched.
+   **For Instance:** Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms platform packages installed multiple version (v16.4.0.54 & v17.1.0.38), Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will be shown Syncfusion<sup style="font-size:70%">&reg;</sup>  package version mismatched.
  
    ![Syncfusion NuGet Packages version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img7.png)
 
-2. Installed Syncfusion NuGet package’s Framework version is differing from the project’s .NET Framework version.
+2. Installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package’s Framework version is differing from the project’s .NET Framework version.
 
-   **For Instance:** Syncfusion.SfBulletGraph.Windows40 NuGet package version(v15.2.0.17 with 4.0 Framework) installed in project, But the project .NET Framework version is 4.5. So, the Syncfusion Troubleshooter will show Syncfusion package Framework version is mismatched.
+   **For Instance:** Syncfusion.SfBulletGraph.Windows40 NuGet package version(v15.2.0.17 with 4.0 Framework) installed in project, But the project .NET Framework version is 4.5. So, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  package Framework version is mismatched.
   
    ![Syncfusion NuGet packages Framework version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img8.png)
 
-3. Dependent NuGet package of the installed Syncfusion NuGet packages is missing.
+3. Dependent NuGet package of the installed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages is missing.
 
-   **For Instance:** If install Syncfusion.Chart.Windows NuGet package alone in project, the Syncfusion Troubleshooter will show the Syncfusion.Chart.Base and other dependent NuGet package missing.
+   **For Instance:** If install Syncfusion.Chart.Windows NuGet package alone in project, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show the Syncfusion.Chart.Base and other dependent NuGet package missing.
  
    ![Dependent NuGet package missing issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img9.png)
 
@@ -104,23 +104,23 @@ I> Internet connection is required to restore the missing dependent packages. If
 
 ### Toolbox Configuration Issues
 
-The Syncfusion Troubleshooter deals with the following Toolbox Configuration related issues in Syncfusion projects. 
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter deals with the following Toolbox Configuration related issues in Syncfusion<sup style="font-size:70%">&reg;</sup>  projects. 
 
-1. If the project .NET Framework version is not installed/configured Syncfusion Toolbox, the Syncfusion Troubleshooter will show Syncfusion Toolbox .NET Framework version is mismatched. 
+1. If the project .NET Framework version is not installed/configured Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox .NET Framework version is mismatched. 
 
-   **For Instance:** The project .NET Framework version is 4.5 and Syncfusion Toolbox is not configured 4.6 framework assemblies only in corresponding Visual Studio, the Syncfusion Troubleshooter will show Syncfusion Toolbox framework version mismatched.
+   **For Instance:** The project .NET Framework version is 4.5 and Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox is not configured 4.6 framework assemblies only in corresponding Visual Studio, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox framework version mismatched.
  
    ![Syncfusion Toolbox Framework version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img10.png)
 
-2. If Syncfusion Toolbox configured version is differed from latest Syncfusion assembly reference version or NuGet package version in same project, the Syncfusion Troubleshooter will show Syncfusion Toolbox version is mismatched.
+2. If Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox configured version is differed from latest Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference version or NuGet package version in same project, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox version is mismatched.
 
-   **For Instance:** If latest Syncfusion assembly reference version is v17.1.0.38 but Toolbox assemblies configured v17.1.0.32, the Syncfusion Troubleshooter will show Syncfusion Toolbox version mismatched.
+   **For Instance:** If latest Syncfusion<sup style="font-size:70%">&reg;</sup>  assembly reference version is v17.1.0.38 but Toolbox assemblies configured v17.1.0.32, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter will show Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox version mismatched.
   
    ![Syncfusion Toolbox version mismatched issue shown in Troubleshooter wizard](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img11.png)
 
 ## Apply the solution
 
-1. After loading the Syncfusion Troubleshooter dialog, check the corresponding check box of the issue to be resolved. Then click the “Fix Issue(s)” button. 
+1. After loading the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter dialog, check the corresponding check box of the issue to be resolved. Then click the “Fix Issue(s)” button. 
 
    ![Syncfusion Troubleshooter wizard with project configuration issues](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img12.png)
 
@@ -128,10 +128,10 @@ The Syncfusion Troubleshooter deals with the following Toolbox Configuration rel
 
    ![Syncfusion Troubleshooter backup dialog](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img13.jpeg)
 
-3. Wait for a while, the Syncfusion Troubleshooter is resolving the selected issues. After the troubleshooting process completed, there will be a status message in the Visual Studio status bar as “Troubleshooting process completed successfully”.
+3. Wait for a while, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Troubleshooter is resolving the selected issues. After the troubleshooting process completed, there will be a status message in the Visual Studio status bar as “Troubleshooting process completed successfully”.
 
    ![Syncfusion Troubleshooter process success status message in visual studio status bar](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img14.jpeg)
 
-4. Then, Syncfusion licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.   
+4. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown, if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the  [help topic](https://help.syncfusion.com/common/essential-studio/licensing/license-key#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio<sup style="font-size:70%">&reg;</sup>.   
 
-   ![Syncfusion license registration required information dialog in Syncfusion Troubleshooter](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img15.jpeg)
+   ![Syncfusion license registration required information dialog in Syncfusion  Troubleshooter](SyncfusionTroubleshooter_images/SyncfusionTroubleshooter-img15.jpeg)

--- a/Extension/WindowsForms-Extension/download-and-installation.md
+++ b/Extension/WindowsForms-Extension/download-and-installation.md
@@ -3,7 +3,7 @@ layout: post
 title: Downloand and Installation | WinForms | Syncfusion
 description: this section provide the information about how to download and install the extensions in Visual Studio.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
@@ -13,13 +13,13 @@ Syncfusion publishes the Visual Studio extension in the [Visual Studio marketpla
 
 ## Prerequisites
 
-The following software prerequisites must be installed to install the Syncfusion WinForms extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion WinForms applications.
+The following software prerequisites must be installed to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms extension, as well as to creating, adding snippet, converting, and upgrading Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms applications.
 
 * [Visual Studio 2010 or later](https://visualstudio.microsoft.com/downloads).
 
 ## Install through the Visual Studio Manage Extensions
 
-The steps below assist you to how to install the Syncfusion WinForms extensions from **Visual Studio Manage Extensions**.
+The steps below assist you to how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  WinForms extensions from **Visual Studio Manage Extensions**.
 
 1. Open the Visual Studio 2019.
 
@@ -41,13 +41,13 @@ The steps below assist you to how to install the Syncfusion WinForms extensions 
 
 7. After the installation is complete, open Visual Studio 2019.
 
-8. Now, under the menu **Extensions**, you can use the Syncfusion extensions from the Visual Studio.
+8. Now, under the menu **Extensions**, you can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio.
 
     ![SyncfusionMenu](Download-Installation-Images/SyncfusionMenu.png)
 
 ## Install from the Visual Studio Marketplace
 
-The steps below illustrate how to download and install the Syncfusion Windows extension from the Visual Studio Marketplace.
+The steps below illustrate how to download and install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Windows extension from the Visual Studio Marketplace.
 
 1. Download the [Syncfusion WinForms Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Windows-Extensions) from the Visual Studio Marketplace.
 
@@ -59,6 +59,6 @@ The steps below illustrate how to download and install the Syncfusion Windows ex
 
 4. Click the **Modify** button.
 
-5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion extensions from the Visual Studio under the **Extensions** menu.
+5. After the installation is complete, open Visual Studio 2019. You can now use Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio under the **Extensions** menu.
 
      ![SyncfusionMenu](Download-Installation-Images/SyncfusionMenu.png)

--- a/Extension/Xamarin-Extension/Check-for-Updates.md
+++ b/Extension/Xamarin-Extension/Check-for-Updates.md
@@ -1,17 +1,17 @@
 ---
 layout: post
 title: Check for Updates | Xamarin | Syncfusion
-description: Syncfusion Check for Updates provides Extensions to update most recent version of the Essential Studio release.
+description: Syncfusion  Check for Updates provides Extensions to update most recent version of the Essential Studio  release.
 platform: extension
 control: Visual Studio Extensions
 documentation: ug
 ---
 
-# Check for Updates in Syncfusion Xamarin
+# Check for Updates in Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin
 
-Syncfusion provides Extensions to update the most recent version of the Essential Studio release. Installing the most recent version ensures that you always have the most up-to-date features, fixes, and improvements.
+Syncfusion<sup style="font-size:70%">&reg;</sup> provides Extensions to update the most recent version of the Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Installing the most recent version ensures that you always have the most up-to-date features, fixes, and improvements.
 
-I> The Syncfusion Check for updates is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Check for updates is available from v17.1.0.32.
 
 You can check updates availability in Visual Studio, and then install the update version if required.
 
@@ -19,7 +19,7 @@ You can check updates availability in Visual Studio, and then install the update
 
    ![Syncfusion check for updates menu](Check-for-Updates_images/Check-for-Updates_images-img1.png)
 
-   N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+   N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
    ![Syncfusion check for updates menu](Check-for-Updates_images/Check-for-Updates_images-img1_2019.png)
    
@@ -27,4 +27,4 @@ You can check updates availability in Visual Studio, and then install the update
 
    ![Syncfusion check for updates wizard](Check-for-Updates_images/Check-for-Updates_images-img2.png)
 
-3. You can download the Syncfusion Essential Studio from the Syncfusion website by selecting **Download**.
+3. You can download the Syncfusion<sup style="font-size:70%">&reg;</sup>  Essential Studio<sup style="font-size:70%">&reg;</sup>  from the Syncfusion<sup style="font-size:70%">&reg;</sup>  website by selecting **Download**.

--- a/Extension/Xamarin-Extension/Create-Project.md
+++ b/Extension/Xamarin-Extension/Create-Project.md
@@ -1,53 +1,53 @@
 ---
 layout: post
 title: Create Project | xamarin | Syncfusion
-description: Syncfusion Project Templates Extension creates the Syncfusion Xamarin Application by adding the required Syncfusion NuGet packages.
+description: Syncfusion  Project Templates Extension creates the Syncfusion  Xamarin Application by adding the required Syncfusion  NuGet packages.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Creating Syncfusion Xamarin Application
+# Creating Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Application
 
-Syncfusion provides Visual Studio Project Templates for the Syncfusion Xamarin platform, allowing you to quickly develop a Syncfusion Xamarin application by just adding the needed Syncfusion NuGet packages for the control you want to use.
+Syncfusion provides Visual Studio Project Templates for the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin platform, allowing you to quickly develop a Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin application by just adding the needed Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages for the control you want to use.
 
-I> The Syncfusion Xamarin Project Templates are available from v16.2.0.41.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Project Templates are available from v16.2.0.41.
 
 To create the **Syncfusion Xamarin Application** in Visual Studio 2017, follow these steps
 
 > Check whether the **Xamarin Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by going to **Tools -> Extensions and Updates -> Installed** for Visual Studio 2017 or lower, and **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 by going to **Extensions -> Manage Extensions -> Installed**. If this extension not installed, please install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
 
-1.	Follow one of the instructions below to create a Syncfusion Xamarin project
+1.	Follow one of the instructions below to create a Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin project
 
 	**Option 1:**  
-	Click **Syncfusion Menu** and choose **Essential Studio for Xamarin > Create New Syncfusion Project…** in **Visual Studio**.
+	Click **Syncfusion Menu** and choose **Essential Studio for Xamarin > Create New Syncfusion<sup style="font-size:70%">&reg;</sup>  Project…** in **Visual Studio**.
 
-	![Choose Syncfusion Xamarin application from Visual Studio new project dialog via Syncfusion menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate.png)
+	![Choose Syncfusion  Xamarin application from Visual Studio new project dialog via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate.png)
 
-	N> From Visual Studio 2019, Syncfusion menu is available under Extensions in Visual Studio menu.
+	N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu is available under Extensions in Visual Studio menu.
 
-	![Choose Syncfusion Xamarin application from Visual Studio new project dialog via Syncfusion menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate_2019.png)
+	![Choose Syncfusion  Xamarin application from Visual Studio new project dialog via Syncfusion<sup style="font-size:70%">&reg;</sup>  menu](Syncfusion-Project-Templates_images/Syncfusion_Menu_ProjectTemplate_2019.png)
 
 	**Option 2:**  
-	Choose **File > New > Project** and navigate to **Syncfusion > Cross-Platform > Syncfusion Xamarin Project Template** in **Visual Studio**.
+	Choose **File > New > Project** and navigate to **Syncfusion > Cross-Platform > Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Project Template** in **Visual Studio**.
 
 	![Choose Syncfusion Xamarin application from Visual Studio new project dialog](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img1.jpeg)
 
-	In Visual Studio 2019, Syncfusion Xamarin project creation wizard like below.
+	In Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin project creation wizard like below.
 
-	![Choose Syncfusion Xamarin application from Visual Studio new project dialog](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img1_2019.png)
+	![Choose Syncfusion  Xamarin application from Visual Studio new project dialog](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img1_2019.png)
 
 2.	Click **OK** once you've given the **project  name**, selected a destination location, and set the project's Framework. The Project Configuration Wizard is now displayed.
    
-3.	Choose the Project, Android, iOS, and UWP by on/off in the following Project Configuration window to configure the Syncfusion Xamarin Application.
+3.	Choose the Project, Android, iOS, and UWP by on/off in the following Project Configuration window to configure the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Application.
 
     ![Syncfusion Xamarin project configuaration wizard](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img2.jpeg)
 
 	**Project Configuration:**
 
-	**Assemblies From:** Choose NuGet or Installed Location to load the Syncfusion Xamarin reference into Xamarin Application.
+	**Assemblies From:** Choose NuGet or Installed Location to load the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin reference into Xamarin Application.
 
-	N> Installed location option will be shown only when the Syncfusion Xamarin setup has been installed.
+	N> Installed location option will be shown only when the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin setup has been installed.
 
 	**Android**
 
@@ -59,46 +59,46 @@ To create the **Syncfusion Xamarin Application** in Visual Studio 2017, follow t
 	1. **Target Device:**  Choose the Xamarin.iOS device of Xamarin.iOS project either Unified, iPhone/iPod, or iPad.
 	2. **Target Version:** Select the Xamarin.iOS Project version.
 
-	**Choose controls:** To create the Syncfusion Xamarin application, choose at least one Syncfusion control. 
+	**Choose controls:** To create the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin application, choose at least one Syncfusion<sup style="font-size:70%">&reg;</sup>  control. 
 
-	N> If you want to add other Syncfusion Xamarin controls in the created Syncfusion Xamarin application, you can use our [Syncfusion Xamarin toolbox](https://help.syncfusion.com/xamarin/visual-studio-integration/toolbox-control)
+	N> If you want to add other Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin controls in the created Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin application, you can use our [Syncfusion Xamarin toolbox](https://help.syncfusion.com/xamarin/visual-studio-integration/toolbox-control)
 
-	![Choose Syncfusion Xamarin control](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img4.png)
+	![Choose Syncfusion  Xamarin control](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img4.png)
 
-4.	The Syncfusion Xamarin Application has been created when you click **Create**.
+4.	The Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Application has been created when you click **Create**.
 
 	N> Choose any one of the project type and controls from Project Configuration Wizard.
 
-	![Selected Syncfusion Xamarin control assemblies added to the UWP project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img13.PNG)
+	![Selected Syncfusion  Xamarin control assemblies added to the UWP project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img13.PNG)
 
-5.	Based on the control selected, required Syncfusion NuGet/Assemblies and configuration have been added to the project.
+5.	Based on the control selected, required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet/Assemblies and configuration have been added to the project.
 
 	**Net Standard /PCL**
 
-	![Selected Syncfusion Xamarin control NuGet package installed in project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img3.jpeg)
+	![Selected Syncfusion  Xamarin control NuGet package installed in project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img3.jpeg)
 
-	![Selected Syncfusion Xamarin control assemblies added to the project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img5.jpeg)
+	![Selected Syncfusion  Xamarin control assemblies added to the project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img5.jpeg)
 
 	**Android**
 
-	![Selected Syncfusion Xamarin control Android NuGet package](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img6.jpeg)
+	![Selected Syncfusion  Xamarin control Android NuGet package](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img6.jpeg)
 
-	![Selected Syncfusion Xamarin control assemblies added to the Android project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img7.jpeg)
+	![Selected Syncfusion  Xamarin control assemblies added to the Android project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img7.jpeg)
 
 	**iOS**
 
-	![Selected Syncfusion Xamarin control iOS NuGet package](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img8.jpeg)
+	![Selected Syncfusion  Xamarin control iOS NuGet package](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img8.jpeg)
 
 	![Selected Syncfusion Xamarin control assemblies added to the iOS project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img9.jpeg)
 
 	**UWP**
 
-	![Selected Syncfusion Xamarin control UWP NuGet package](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img10.jpeg)
+	![Selected Syncfusion  Xamarin control UWP NuGet package](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img10.jpeg)
 
 	![Selected Syncfusion Xamarin control assemblies added to the UWP project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img11.jpeg)
 
-6.	Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+6.	Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
 
-	![Syncfusion license registration required information dialog in Syncfusion Xamarin Project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img12.jpeg)
+	![Syncfusion license registration required information dialog in Syncfusion  Xamarin Project](Syncfusion-Project-Templates_images/Syncfusion-Project-Templates-img12.jpeg)
 
 

--- a/Extension/Xamarin-Extension/Download-and-Installation.md
+++ b/Extension/Xamarin-Extension/Download-and-Installation.md
@@ -1,20 +1,20 @@
 ---
 layout: post
 title: Download and Installation | Xamarin | Syncfusion
-description: How to download and install the Syncfusion Xamarin Visual Studio Extensions from Visual Studio Market Place
+description: How to download and install the Syncfusion  Xamarin Visual Studio Extensions from Visual Studio Market Place
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 
 # Download and Installation
 
-In [Visual Studio marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.XamarinExtension), Syncfusion publishing the Xamarin Visual Studio extension. You can either use the Visual Studio to install it or go to the Visual Studio marketplace to download and install it.
+In [Visual Studio marketplace](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.XamarinExtension), Syncfusion<sup style="font-size:70%">&reg;</sup>  publishing the Xamarin Visual Studio extension. You can either use the Visual Studio to install it or go to the Visual Studio marketplace to download and install it.
 
 ## Install through the Visual Studio Manage Extensions
 
-The steps below assist you to how to install the Syncfusion Xamarin extensions from Visual Studio **Manage Extensions**.
+The steps below assist you to how to install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin extensions from Visual Studio **Manage Extensions**.
 
 1.	Open the Visual Studio.
 2.	Navigate to **Extension -> Manage Extensions** and open the Manage Extensions.
@@ -28,13 +28,13 @@ The steps below assist you to how to install the Syncfusion Xamarin extensions f
 	![Vsix Modify Window](Download-and-Installation-images/VSIXModify.PNG)
 6.	Click the **Modify** button.
 7.	When the installation is finished, launch the Visual Studio.
-8.	Now, you can use the Syncfusion extensions from Visual Studio under the Extensions menu.
+8.	Now, you can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from Visual Studio under the Extensions menu.
 	
 	![Syncfusion Xamarin Menu](Download-and-Installation-images/SyncfusionXamarinMenu.png)
 
 ##	Install from the Visual Studio Marketplace
 
-The steps below illustrate how to download and install the Syncfusion Xamarin extension from the Visual Studio Marketplace.
+The steps below illustrate how to download and install the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin extension from the Visual Studio Marketplace.
 
 1.	Download the [Syncfusion Xamarin Extensions](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.XamarinExtension) from the Visual Studio Marketplace.
 2.	If any Visual Studio instances are still open, close them.
@@ -42,6 +42,6 @@ The steps below illustrate how to download and install the Syncfusion Xamarin ex
 	
 	![Vsix Modify Window](Download-and-Installation-images/VSIXInstall.png)
 4.	Click the **Install** button.
-5.	After the installation is complete, open Visual Studio 2019. You can now use Syncfusion extensions from the Visual Studio under the Extensions menu.
+5.	After the installation is complete, open Visual Studio 2019. You can now use Syncfusion<sup style="font-size:70%">&reg;</sup>  extensions from the Visual Studio under the Extensions menu.
 	
 	![Syncfusion Xamarin Menu](Download-and-Installation-images/SyncfusionXamarinMenu.png)

--- a/Extension/Xamarin-Extension/Essential-UI-Kit.md
+++ b/Extension/Xamarin-Extension/Essential-UI-Kit.md
@@ -1,29 +1,29 @@
 ---
 layout: post
 title: Essential UI Kit | Xamarin | Syncfusion
-description: The Syncfusion Xamarin Essential UI Kit extension provides the predefined design for the Xamarin.Forms.
+description: The Syncfusion  Xamarin Essential UI Kit extension provides the predefined design for the Xamarin.Forms.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Xamarin Essential UI Kit
+# Xamarin Essential<sup style="font-size:70%">&reg;</sup> UI Kit
 
-Essential UI Kit for Xamarin.Forms includes predefined XAML templates for Xamarin.Forms apps. The UI kit allows to build a user interface in a cross-platform application. It clearly separates the View, View Model, and Model classes, making it simple to integrate your business logic and make changes to the existing view. 
+Essential<sup style="font-size:70%">&reg;</sup> UI Kit for Xamarin.Forms includes predefined XAML templates for Xamarin.Forms apps. The UI kit allows to build a user interface in a cross-platform application. It clearly separates the View, View Model, and Model classes, making it simple to integrate your business logic and make changes to the existing view. 
 
 ## Installation of Xamarin UI Kit Extension
 
-Install the appropriate [Xamarin UI Kit Extension](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Essential-UI-Kit-Xamarin-Forms) in Visual Studio by downloading them from the marketplace. As a result, you can use the Syncfusion Extension from your project's Syncfusion menu.
+Install the appropriate [Xamarin UI Kit Extension](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Essential-UI-Kit-Xamarin-Forms) in Visual Studio by downloading them from the marketplace. As a result, you can use the Syncfusion<sup style="font-size:70%">&reg;</sup>  Extension from your project's Syncfusion<sup style="font-size:70%">&reg;</sup>  menu.
 
 ## Include XAML templates in Xamarin.Forms apps
 
 1.	Launch a new or existing Xamarin application.
 
-2.	Select the **Essential UI Kit for Xamarin.Forms** from the **Solution Explorer** by right-clicking on your **Xamarin.Forms** project
+2.	Select the **Essential<sup style="font-size:70%">&reg;</sup> UI Kit for Xamarin.Forms** from the **Solution Explorer** by right-clicking on your **Xamarin.Forms** project
 
 	![Syncfusion Essential UI Kit Context menu](Essential-UI-Kit-images/Context-Menu.png)
 
-	N> The Essential UI Kit for Xamarin.Forms add-in will be shown when the project has the Xamarin.Forms NuGet package as a reference and also, Xamarin.Forms project should be a NET Standard project.
+	N> The Essential<sup style="font-size:70%">&reg;</sup> UI Kit for Xamarin.Forms add-in will be shown when the project has the Xamarin.Forms NuGet package as a reference and also, Xamarin.Forms project should be a NET Standard project.
 
 3.	The Category dialogue box will then appear, with its pre-defined template.
 
@@ -35,7 +35,7 @@ Install the appropriate [Xamarin UI Kit Extension](https://marketplace.visualstu
 
 	![Edit page Name](Essential-UI-Kit-images/edit-page-name.png)
 
-6.	The selected pages will be added along with View, View Model, Model classes, resource files and Syncfusion NuGet package reference,
+6.	The selected pages will be added along with View, View Model, Model classes, resource files and Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package reference,
 
 	![MVVM files](Essential-UI-Kit-images/mvvm-files.png)
 
@@ -43,7 +43,7 @@ Install the appropriate [Xamarin UI Kit Extension](https://marketplace.visualstu
 
 	![Added Resources](Essential-UI-Kit-images/Resources.png)
 
-7.	Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio. 
+7.	Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio. 
 
 ## Run the UI template item
 

--- a/Extension/Xamarin-Extension/Overview.md
+++ b/Extension/Xamarin-Extension/Overview.md
@@ -1,26 +1,26 @@
 ---
 layout: post
 title: Xamarin Extension | Extension | Syncfusion
-description: The Syncfusion Xamarin Extensions provide quick access to create or configure the Syncfusion Xamarin projects
+description: The Syncfusion  Xamarin Extensions provide quick access to create or configure the Syncfusion  Xamarin projects
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
 # Xamarin Extension Overview
 
-The Syncfusion Xamarin  Visual Studio Extensions can be accessed through the Syncfusion Menu to create and configure the project with Syncfusion references in Visual Studio.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin  Visual Studio Extensions can be accessed through the Syncfusion<sup style="font-size:70%">&reg;</sup>  Menu to create and configure the project with Syncfusion<sup style="font-size:70%">&reg;</sup>  references in Visual Studio.
 
-I> The Syncfusion Xamarin  menu option is available from v17.1.0.32.
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin  menu option is available from v17.1.0.32.
 
-The Syncfusion provides the following extension supports in Visual Studio:
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  provides the following extension supports in Visual Studio:
 
-1.	[Syncfusion Xamarin Project Template](https://help.syncfusion.com/extension/xamarin-extension/create-project): Create the Syncfusion Xamarin application by adding the required Syncfusion NuGet based on the control chosen.
-2.	[Essential UI Kit](https://help.syncfusion.com/extension/xamarin-extension/essential-ui-kit#template-selection-and-naming): Add the predefined Syncfusion XAML templates in Xamarin.Form and install the required Syncfusion NuGet packages.
+1.	[Syncfusion Xamarin Project Template](https://help.syncfusion.com/extension/xamarin-extension/create-project): Create the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin application by adding the required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet based on the control chosen.
+2.	[Essential UI Kit](https://help.syncfusion.com/extension/xamarin-extension/essential-ui-kit#template-selection-and-naming): Add the predefined Syncfusion<sup style="font-size:70%">&reg;</sup>  XAML templates in Xamarin.Form and install the required Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages.
 
      N> Xamarin Item Template is available only in marketplace. 
 
-3.	[Toolbox](https://help.syncfusion.com/extension/xamarin-extension/toolbox): Add the Syncfusion Xamarin components in Xamarin.Forms designer.
+3.	[Toolbox](https://help.syncfusion.com/extension/xamarin-extension/toolbox): Add the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin components in Xamarin.Forms designer.
 
 
 **No project selected in Visual Studio**
@@ -31,4 +31,4 @@ The Syncfusion provides the following extension supports in Visual Studio:
 
 ![Syncfusion Menu when Selected Microsoft/Syncfusion Xamarin in Visual Studio](Overview_images/Syncfusion_Menu_OverView2.png)
 
-N> From Visual Studio 2019, Syncfusion menu available under Extension in Visual Studio menu.
+N> From Visual Studio 2019, Syncfusion<sup style="font-size:70%">&reg;</sup>  menu available under Extension in Visual Studio menu.

--- a/Extension/Xamarin-Extension/Syncfusion-Notifications.md
+++ b/Extension/Xamarin-Extension/Syncfusion-Notifications.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Notifications | Xamarin | Syncfusion
-description: For displaying the notifications about trial and newer version update information for Syncfusion applications.
+description: For displaying the notifications about trial and newer version update information for Syncfusion  applications.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Notifications
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Notifications
 
-Syncfusion enhances the user experience in Xamarin applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion trial assemblies, updates regarding the availability of the latest Syncfusion NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion ensures that developers stay updated with Syncfusion latest features and enhancements.
+Syncfusion enhances the user experience in Xamarin applications through notification messages. These notifications cover various aspects, including alerts for trial applications when utilizing Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies, updates regarding the availability of the latest Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet package, and notifications regarding newer releases of Essential Studio. By keeping users informed, Syncfusion<sup style="font-size:70%">&reg;</sup>  ensures that developers stay updated with Syncfusion<sup style="font-size:70%">&reg;</sup>  latest features and enhancements.
 
-N> The Syncfusion Notification feature is available from Essential Studio v22.1.34.
+N> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Notification feature is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  v22.1.34.
 
 ## Notification Configuration
 
-The Syncfusion Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
+The Syncfusion<sup style="font-size:70%">&reg;</sup>  Options page allows you to configure notification settings. Customise trial and newer version notifications with a simple true or false toggle.
 
-It can be accessed by clicking **Tools -> Options -> Syncfusion -> Xamarin**
+It can be accessed by clicking **Tools -> Options -> Syncfusion<sup style="font-size:70%">&reg;</sup>  -> Xamarin**
 
 ![Option Page](images/xamarin-optionPage.png)
 
 ## Notification Types
 
-**1. Syncfusion Trial Application Notification**
+**1. Syncfusion<sup style="font-size:70%">&reg;</sup>  Trial Application Notification**
 
-When you utilize Syncfusion trial assemblies in your Xamarin application, you will receive a notification stating, **This application uses a trial Syncfusion license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
+When you utilize Syncfusion<sup style="font-size:70%">&reg;</sup>  trial assemblies in your Xamarin application, you will receive a notification stating, **This application uses a trial Syncfusion<sup style="font-size:70%">&reg;</sup>  license.** This notification encourages you to obtain a valid license key, enabling you to fully explore and experience the extensive features and capabilities offered by Syncfusion.
 
 ![Trial Notification](images/xamarin-trial.png)
 
-**2. Newer Syncfusion NuGet Package Notification**
+**2. Newer Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet Package Notification**
 
-If you have installed lower versions of Syncfusion NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
+If you have installed lower versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages in your application, you will be notified about the availability of higher versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  NuGet packages on nuget.org. This empowers you to easily identify opportunities to upgrade and gain access to new features, performance enhancements, and bug fixes.
 
 ![NuGet Notification](images/xamarin-nuget.png)
 
-**3. Newer Essential Studio Build Notification**
+**3. Newer Essential Studio<sup style="font-size:70%">&reg;</sup>  Build Notification**
 
-If you use older versions of Syncfusion assemblies or NuGet packages from **Essential Studio Xamarin,** Syncfusion will notify you about new releases for the latest Essential Studio build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion in your Xamarin development projects.
+If you use older versions of Syncfusion<sup style="font-size:70%">&reg;</sup>  assemblies or NuGet packages from **Essential Studio Xamarin,** Syncfusion<sup style="font-size:70%">&reg;</sup>  will notify you about new releases for the latest Essential Studio<sup style="font-size:70%">&reg;</sup>  build. Updating to the newest version ensures access to recent features, enhancements, and important updates, maximizing the capabilities of Syncfusion<sup style="font-size:70%">&reg;</sup>  in your Xamarin development projects.
 
 ![Build Notification](images/xamarin-build.png)
 
 **4. Invalid License Key Notification**
 
-If you have mistakenly used an incorrect license key or used a license from another version or platform in your Xamarin application, Syncfusion will display a notification message stating, **The provided Syncfusion license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion components.
+If you have mistakenly used an incorrect license key or used a license from another version or platform in your Xamarin application, Syncfusion<sup style="font-size:70%">&reg;</sup>  will display a notification message stating, **The provided Syncfusion<sup style="font-size:70%">&reg;</sup>  license key is invalid.** This message serves as a reminder to obtain a valid license key and ensure proper licensing for Syncfusion<sup style="font-size:70%">&reg;</sup>  components.
 
 ![Invalid Notification](images/xamarin-invalid.png)
 

--- a/Extension/Xamarin-Extension/Toolbox.md
+++ b/Extension/Xamarin-Extension/Toolbox.md
@@ -1,49 +1,49 @@
 ---
 layout: post
 title: Toolbox Control | xamarin | Syncfusion
-description: Syncfusion Xamarin Toolbox to add the Syncfusion Xamarin (Xamarin.Forms) controls in your project without coding in the Visual Studio designer.
+description: Syncfusion  Xamarin Toolbox to add the Syncfusion  Xamarin (Xamarin.Forms) controls in your project without coding in the Visual Studio designer.
 platform: extension
-control: Syncfusion Extensions
+control: Syncfusion  Extensions
 documentation: ug
 ---
 
-# Syncfusion Xamarin Toolbox
+# Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Toolbox
 
-Syncfusion provides a Syncfusion **Visual Studio** Toolbox for the Xamarin platform to include the Syncfusion Xamarin (Xamarin.Forms) components in Xamarin application. It supports from Visual Studio 2017. The Syncfusion Xamarin toolbox allows you to add a Syncfusion Xamarin component code to the application effortlessly at the appropriate place in the XAML design file.
+Syncfusion provides a Syncfusion<sup style="font-size:70%">&reg;</sup>  **Visual Studio** Toolbox for the Xamarin platform to include the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin (Xamarin.Forms) components in Xamarin application. It supports from Visual Studio 2017. The Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin toolbox allows you to add a Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin component code to the application effortlessly at the appropriate place in the XAML design file.
 
-I> The Syncfusion Xamarin Toolbox is available from Essential Studio 2018 Volume 2(v16.2.0.41).
+I> The Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Toolbox is available from Essential Studio<sup style="font-size:70%">&reg;</sup>  2018 Volume 2(v16.2.0.41).
 
 > Check whether the **Xamarin Extensions - Syncfusion** are installed or not in Visual Studio Extension Manager by navigating to **Tools -> Extensions and Updates -> Installed** for Visual Studio 2017, and **Extensions -> Manage Extensions -> Installed** for Visual Studio 2019 by navigating to **Extensions -> Manage Extensions -> Installed**. If this extension not installed, please install the extension by follow the steps from the [download and installation](download-and-installation) help topic.
 
-## Launching Syncfusion Xamarin Toolbox from Syncfusion menu
+## Launching Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Toolbox from Syncfusion<sup style="font-size:70%">&reg;</sup>  menu
 
 **Visual Studio 2019 and later**
 
-To launch the Syncfusion Toolbox from Visual Studio 2019 and later, click **Extensions** in Visual Studio menu and choose **Syncfusion > Essential Studio for Xamarin > Launch Toolbox…**
+To launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox from Visual Studio 2019 and later, click **Extensions** in Visual Studio menu and choose **Syncfusion > Essential Studio<sup style="font-size:70%">&reg;</sup>  for Xamarin > Launch Toolbox…**
 
-   ![Syncfusion Xamarin Custom Toolbox via Syncfusion menu](Toolbox_images/Syncfusion_Menu_Toolbox_2019.png)
+   ![Syncfusion Xamarin Custom Toolbox via Syncfusion  menu](Toolbox_images/Syncfusion_Menu_Toolbox_2019.png)
 
 **Visual Studio 2017**
 
-To launch the Syncfusion Toolbox from Visual Studio 2017, click **Syncfusion** in Visual Studio menu and choose **Essential Studio for Xamarin > Launch Toolbox...**
+To launch the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox from Visual Studio 2017, click **Syncfusion** in Visual Studio menu and choose **Essential Studio for Xamarin > Launch Toolbox...**
 
 
-   ![Syncfusion Xamarin Custom Toolbox via Syncfusion menu](Toolbox_images/Syncfusion_Menu_Toolbox.png)
+   ![Syncfusion Xamarin Custom Toolbox via Syncfusion  menu](Toolbox_images/Syncfusion_Menu_Toolbox.png)
 
-## Launching Syncfusion Xamarin Toolbox from View menu
+## Launching Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin Toolbox from View menu
 
-To launch the Visual Studio Toolbox from Visual Studio menu in Visual Studio 2017 and later, click **View > Other Windows > Syncfusion Toolbox** in Visual Studio.
+To launch the Visual Studio Toolbox from Visual Studio menu in Visual Studio 2017 and later, click **View > Other Windows > Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox** in Visual Studio.
 
    ![Syncfusion Xamarin Custom Toolbox menu](Toolbox_images/Toolbox-img1.png)
 
-> You can also find the Syncfusion Toolbox option  by typing "Syncfusion Toolbox" into the Quick Launch search field (top right corner in Visual Studio).
+> You can also find the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox option  by typing "Syncfusion Toolbox" into the Quick Launch search field (top right corner in Visual Studio).
 
    ![Syncfusion Xamarin Custom Toolbox menu](Toolbox_images/quick-launchToolbox-img.png)
 
-## Render Syncfusion components 
+## Render Syncfusion<sup style="font-size:70%">&reg;</sup>  components 
    
-1.	When you click the Syncfusion Toolbox window, the Syncfusion Toolbox wizard is launched, and Syncfusion components are enabled once you access your application's designer page (XAML). Syncfusion components will not appear until open the appropriate  design (XAML) file from the Xamarin shared/.NET Standard/PCL project. The rendering of the Syncfusion Xamarin components is made as simple as possible. All you need to do simply dragging and dropping the Syncfusion Xamarin component from the Syncfusion toolbox into the designer. The selected component's code snippet and namespace will be added to the designer page(XAML) and  the required Syncfusion Xamarin NuGet packages will be installed.
+1.	When you click the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox window, the Syncfusion<sup style="font-size:70%">&reg;</sup>  Toolbox wizard is launched, and Syncfusion<sup style="font-size:70%">&reg;</sup>  components are enabled once you access your application's designer page (XAML). Syncfusion<sup style="font-size:70%">&reg;</sup>  components will not appear until open the appropriate  design (XAML) file from the Xamarin shared/.NET Standard/PCL project. The rendering of the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin components is made as simple as possible. All you need to do simply dragging and dropping the Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin component from the Syncfusion<sup style="font-size:70%">&reg;</sup>  toolbox into the designer. The selected component's code snippet and namespace will be added to the designer page(XAML) and  the required Syncfusion<sup style="font-size:70%">&reg;</sup>  Xamarin NuGet packages will be installed.
 
       ![Syncfusion Xamarin Toolbox wizard](Toolbox_images/toolbox-gif.gif)
 
-2. Then, Syncfusion licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.
+2. Then, Syncfusion<sup style="font-size:70%">&reg;</sup>  licensing registration required message box will be shown if you installed the trial setup or NuGet packages since Syncfusion<sup style="font-size:70%">&reg;</sup>  introduced the licensing system from 2018 Volume 2 (v16.2.0.41) Essential Studio<sup style="font-size:70%">&reg;</sup>  release. Navigate to the [help topic](https://help.syncfusion.com/common/essential-studio/licensing/overview#how-to-generate-syncfusion-license-key), which is shown in the licensing message box to generate and register the Syncfusion<sup style="font-size:70%">&reg;</sup>  license key to your project. Refer to this [blog](https://blog.syncfusion.com/post/Whats-New-in-2018-Volume-2-Licensing-Changes-in-the-1620x-Version-of-Essential-Studio.aspx) post for understanding the licensing changes introduced in Essential Studio.


### PR DESCRIPTION
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-IN style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr;border-width:100%'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:11.7444in'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:11.7444in'>

<p style='margin:0in;font-family:Calibri;font-size:11.0pt' lang=en-US>&nbsp;</p>

<div style='direction:ltr'>


Title | Description
-- | --
Task Link | Task   194537: Validate the TOC entry values based on files present
Feature   description | Sometimes, the UG publishing for a platform might get failed, but the TOC will be refreshed along   with the release notes publishing automation.        in such   cases, the links for the page will are not yet generated will be shown the   site and it will result in 403 error while clicking it like below.       We need   modify the JSON generation tool in such a way that only the entries for those   files which are already present in server should be processed and we need to   remove other <li> nodes from the platform-toc.html file and then   generate the json file.
Analysis and   design | No design changes         required.
Solution   description | We have to validate the htmlfiles and corresponding toc anchor link
Output screenshots | ![image](https://github.com/user-attachments/assets/e4d6e535-81d8-4cd7-9ee6-b896accc67a8)
Areas affected and   ensured | Changes included   in configure patch assemblies tool and Innosetup file.
Test cases |  
Testbed sample   location | N/A
Additional   CheckList | Did you run the automation         against your fix? No     Is         there any API name change?N/A     Is         there any existing behavior change of other features due to this code         change? No.     Does         your new code introduce new warnings or binding errors? No.     Does         your code pass all FxCop and StyleCop rules? N/A.     Did         you record this case in the unit test or UI test? N/A



</div>

</div>

</div>

</div>

<!--EndFragment-->
</body>

</html>
